### PR TITLE
feat: implement Alert Notification and Current Time services + improv…

### DIFF
--- a/src/bluetooth_sig/gatt/characteristics/__init__.py
+++ b/src/bluetooth_sig/gatt/characteristics/__init__.py
@@ -9,6 +9,10 @@ from __future__ import annotations
 
 # Import the registry components from the dedicated registry module
 # Import all individual characteristic classes for backward compatibility
+from .alert_level import AlertLevelCharacteristic
+from .alert_notification_control_point import (
+    AlertNotificationControlPointCharacteristic,
+)
 from .ammonia_concentration import AmmoniaConcentrationCharacteristic
 from .apparent_wind_direction import ApparentWindDirectionCharacteristic
 from .apparent_wind_speed import ApparentWindSpeedCharacteristic
@@ -25,6 +29,7 @@ from .body_composition_measurement import BodyCompositionMeasurementCharacterist
 from .co2_concentration import CO2ConcentrationCharacteristic
 from .csc_feature import CSCFeatureCharacteristic
 from .csc_measurement import CSCMeasurementCharacteristic
+from .current_time import CurrentTimeCharacteristic
 from .cycling_power_control_point import CyclingPowerControlPointCharacteristic
 from .cycling_power_feature import CyclingPowerFeatureCharacteristic
 from .cycling_power_measurement import CyclingPowerMeasurementCharacteristic
@@ -69,6 +74,7 @@ from .magnetic_flux_density_2d import MagneticFluxDensity2DCharacteristic
 from .magnetic_flux_density_3d import MagneticFluxDensity3DCharacteristic
 from .methane_concentration import MethaneConcentrationCharacteristic
 from .navigation import NavigationCharacteristic
+from .new_alert import NewAlertCharacteristic
 from .nitrogen_dioxide_concentration import NitrogenDioxideConcentrationCharacteristic
 from .noise import NoiseCharacteristic
 from .non_methane_voc_concentration import NonMethaneVOCConcentrationCharacteristic
@@ -81,6 +87,7 @@ from .position_quality import PositionQualityCharacteristic
 from .pressure import PressureCharacteristic
 from .pulse_oximetry_measurement import PulseOximetryMeasurementCharacteristic
 from .rainfall import RainfallCharacteristic
+from .reference_time_information import ReferenceTimeInformationCharacteristic
 from .registry import (
     CHARACTERISTIC_CLASS_MAP,
     CharacteristicName,
@@ -89,13 +96,18 @@ from .registry import (
 from .rsc_feature import RSCFeatureCharacteristic
 from .rsc_measurement import RSCMeasurementCharacteristic
 from .sulfur_dioxide_concentration import SulfurDioxideConcentrationCharacteristic
+from .supported_new_alert_category import SupportedNewAlertCategoryCharacteristic
 from .supported_power_range import SupportedPowerRangeCharacteristic
+from .supported_unread_alert_category import (
+    SupportedUnreadAlertCategoryCharacteristic,
+)
 from .temperature import TemperatureCharacteristic
 from .temperature_measurement import TemperatureMeasurementCharacteristic
 from .time_zone import TimeZoneCharacteristic
 from .true_wind_direction import TrueWindDirectionCharacteristic
 from .true_wind_speed import TrueWindSpeedCharacteristic
 from .tx_power_level import TxPowerLevelCharacteristic
+from .unread_alert_status import UnreadAlertStatusCharacteristic
 from .uv_index import UVIndexCharacteristic
 from .voc_concentration import VOCConcentrationCharacteristic
 from .voltage import VoltageCharacteristic
@@ -114,6 +126,8 @@ __all__ = [
     # Base characteristic
     "BaseCharacteristic",
     # Individual characteristic classes (for backward compatibility)
+    "AlertLevelCharacteristic",
+    "AlertNotificationControlPointCharacteristic",
     "AmmoniaConcentrationCharacteristic",
     "ApparentWindDirectionCharacteristic",
     "ApparentWindSpeedCharacteristic",
@@ -129,6 +143,7 @@ __all__ = [
     "CO2ConcentrationCharacteristic",
     "CSCFeatureCharacteristic",
     "CSCMeasurementCharacteristic",
+    "CurrentTimeCharacteristic",
     "CyclingPowerControlPointCharacteristic",
     "CyclingPowerFeatureCharacteristic",
     "CyclingPowerMeasurementCharacteristic",
@@ -165,6 +180,7 @@ __all__ = [
     "MethaneConcentrationCharacteristic",
     "ModelNumberStringCharacteristic",
     "NavigationCharacteristic",
+    "NewAlertCharacteristic",
     "NitrogenDioxideConcentrationCharacteristic",
     "NonMethaneVOCConcentrationCharacteristic",
     "OzoneConcentrationCharacteristic",
@@ -176,19 +192,23 @@ __all__ = [
     "PressureCharacteristic",
     "PulseOximetryMeasurementCharacteristic",
     "RainfallCharacteristic",
+    "ReferenceTimeInformationCharacteristic",
     "RSCMeasurementCharacteristic",
     "RSCFeatureCharacteristic",
     "SerialNumberStringCharacteristic",
     "SoftwareRevisionStringCharacteristic",
     "NoiseCharacteristic",
     "SulfurDioxideConcentrationCharacteristic",
+    "SupportedNewAlertCategoryCharacteristic",
     "SupportedPowerRangeCharacteristic",
+    "SupportedUnreadAlertCategoryCharacteristic",
     "TemperatureCharacteristic",
     "TemperatureMeasurementCharacteristic",
     "TimeZoneCharacteristic",
     "TrueWindDirectionCharacteristic",
     "TrueWindSpeedCharacteristic",
     "TxPowerLevelCharacteristic",
+    "UnreadAlertStatusCharacteristic",
     "UVIndexCharacteristic",
     "VOCConcentrationCharacteristic",
     "VoltageCharacteristic",

--- a/src/bluetooth_sig/gatt/characteristics/alert_level.py
+++ b/src/bluetooth_sig/gatt/characteristics/alert_level.py
@@ -1,0 +1,94 @@
+"""Alert Level characteristic implementation."""
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+from bluetooth_sig.types.context import CharacteristicContext
+
+from .base import BaseCharacteristic
+from .templates import Uint8Template
+
+
+class AlertLevel(IntEnum):
+    """Alert level values as defined by Bluetooth SIG.
+
+    Values:
+        NO_ALERT: No alert (0x00)
+        MILD_ALERT: Mild alert (0x01)
+        HIGH_ALERT: High alert (0x02)
+    """
+
+    NO_ALERT = 0x00
+    MILD_ALERT = 0x01
+    HIGH_ALERT = 0x02
+
+
+class AlertLevelCharacteristic(BaseCharacteristic):
+    """Alert Level characteristic (0x2A06).
+
+    org.bluetooth.characteristic.alert_level
+
+    The Alert Level characteristic defines the level of alert and is
+    used by services such as Immediate Alert (0x1802), Link Loss (0x1803),
+    and Phone Alert Status (0x180E).
+
+    Valid values:
+        - 0x00: No Alert
+        - 0x01: Mild Alert
+        - 0x02: High Alert
+        - 0x03-0xFF: Reserved for Future Use
+
+    Spec: Bluetooth SIG GATT Specification Supplement, Alert Level
+    """
+
+    _template = Uint8Template()
+
+    def decode_value(self, data: bytearray, ctx: CharacteristicContext | None = None) -> AlertLevel:
+        """Decode alert level from raw bytes.
+
+        Args:
+            data: Raw bytes from BLE characteristic (1 byte)
+            ctx: Optional context for parsing
+
+        Returns:
+            AlertLevel enum value
+
+        Raises:
+            ValueError: If data is less than 1 byte or value is invalid
+
+        """
+        raw_value = self._template.decode_value(data, offset=0, ctx=ctx)
+
+        # Validate against known values
+        if raw_value not in (AlertLevel.NO_ALERT, AlertLevel.MILD_ALERT, AlertLevel.HIGH_ALERT):
+            raise ValueError(
+                f"Alert Level value {raw_value} is reserved or invalid. "
+                f"Valid values: 0 (No Alert), 1 (Mild Alert), 2 (High Alert)"
+            )
+
+        return AlertLevel(raw_value)
+
+    def encode_value(self, data: AlertLevel | int) -> bytearray:
+        r"""Encode alert level to raw bytes.
+
+        Args:
+            data: AlertLevel enum value or integer (0-2)
+
+        Returns:
+            Encoded characteristic data (1 byte)
+
+        Raises:
+            ValueError: If data is not 0, 1, or 2
+
+        """
+        # Convert AlertLevel to int if needed
+        int_value = int(data) if isinstance(data, AlertLevel) else data
+
+        # Validate range
+        if int_value not in (AlertLevel.NO_ALERT, AlertLevel.MILD_ALERT, AlertLevel.HIGH_ALERT):
+            raise ValueError(
+                f"Alert Level value {int_value} is invalid. Valid values: 0 (No Alert), 1 (Mild Alert), 2 (High Alert)"
+            )
+
+        return self._template.encode_value(int_value)

--- a/src/bluetooth_sig/gatt/characteristics/alert_notification_control_point.py
+++ b/src/bluetooth_sig/gatt/characteristics/alert_notification_control_point.py
@@ -1,0 +1,114 @@
+"""Alert Notification Control Point characteristic (0x2A44) implementation.
+
+Control point for enabling/disabling alert notifications and triggering immediate notifications.
+Used by Alert Notification Service (0x1811).
+
+Based on Bluetooth SIG GATT Specification:
+- Alert Notification Control Point: 2 bytes (Command ID + Category ID)
+"""
+
+from __future__ import annotations
+
+import msgspec
+
+from ...types import (
+    ALERT_COMMAND_MAX,
+    AlertCategoryID,
+    AlertNotificationCommandID,
+    validate_category_id,
+)
+from ..context import CharacteristicContext
+from .base import BaseCharacteristic
+from .utils import DataParser
+
+
+class AlertNotificationControlPointData(msgspec.Struct):
+    """Alert Notification Control Point characteristic data structure."""
+
+    command_id: AlertNotificationCommandID
+    category_id: AlertCategoryID
+
+
+class AlertNotificationControlPointCharacteristic(BaseCharacteristic):
+    """Alert Notification Control Point characteristic (0x2A44).
+
+    Control point for enabling/disabling notifications and requesting immediate alerts.
+
+    Structure (2 bytes):
+    - Command ID: uint8 (0=Enable New Alert, 1=Enable Unread Status, etc.)
+    - Category ID: uint8 (0=Simple Alert, 1=Email, etc. - target category for command)
+
+    Commands:
+    - 0: Enable New Incoming Alert Notification
+    - 1: Enable Unread Category Status Notification
+    - 2: Disable New Incoming Alert Notification
+    - 3: Disable Unread Category Status Notification
+    - 4: Notify New Incoming Alert immediately
+    - 5: Notify Unread Category Status immediately
+
+    Used by Alert Notification Service (0x1811).
+    """
+
+    def decode_value(
+        self, data: bytearray, ctx: CharacteristicContext | None = None
+    ) -> AlertNotificationControlPointData:
+        """Decode Alert Notification Control Point data from bytes.
+
+        Args:
+            data: Raw characteristic data (2 bytes)
+            ctx: Optional characteristic context
+
+        Returns:
+            AlertNotificationControlPointData with all fields
+
+        Raises:
+            ValueError: If data is insufficient or contains invalid values
+
+        """
+        if len(data) < 2:
+            raise ValueError(
+                f"Insufficient data for Alert Notification Control Point: expected 2 bytes, got {len(data)}"
+            )
+
+        # Parse Command ID (1 byte)
+        command_id_raw = DataParser.parse_int8(data, 0, signed=False)
+        if command_id_raw > ALERT_COMMAND_MAX:
+            raise ValueError(f"Invalid command ID: {command_id_raw} (valid range: 0-{ALERT_COMMAND_MAX})")
+        command_id = AlertNotificationCommandID(command_id_raw)
+
+        # Parse Category ID (1 byte)
+        category_id_raw = DataParser.parse_int8(data, 1, signed=False)
+        category_id = validate_category_id(category_id_raw)
+
+        return AlertNotificationControlPointData(
+            command_id=command_id,
+            category_id=category_id,
+        )
+
+    def encode_value(self, data: AlertNotificationControlPointData) -> bytearray:
+        """Encode Alert Notification Control Point data to bytes.
+
+        Args:
+            data: AlertNotificationControlPointData to encode
+
+        Returns:
+            Encoded alert notification control point (2 bytes)
+
+        Raises:
+            ValueError: If data contains invalid values
+
+        """
+        result = bytearray()
+
+        # Encode Command ID (1 byte)
+        command_id_value = int(data.command_id)
+        if command_id_value > ALERT_COMMAND_MAX:
+            raise ValueError(f"Invalid command ID: {command_id_value} (valid range: 0-{ALERT_COMMAND_MAX})")
+        result.append(command_id_value)
+
+        # Encode Category ID (1 byte)
+        category_id_value = int(data.category_id)
+        validate_category_id(category_id_value)  # Validate the category ID value
+        result.append(category_id_value)
+
+        return result

--- a/src/bluetooth_sig/gatt/characteristics/current_time.py
+++ b/src/bluetooth_sig/gatt/characteristics/current_time.py
@@ -1,0 +1,146 @@
+"""Current Time characteristic (0x2A2B) implementation.
+
+Represents exact time with date, time, fractions, and adjustment reasons.
+Used by Current Time Service (0x1805).
+
+Based on Bluetooth SIG GATT Specification:
+- Current Time: 10 bytes (Date Time + Day of Week + Fractions256 + Adjust Reason)
+- Date Time: Year (uint16) + Month + Day + Hours + Minutes + Seconds (7 bytes)
+- Day of Week: uint8 (1=Monday to 7=Sunday, 0=Unknown)
+- Fractions256: uint8 (0-255, representing 1/256 fractions of a second)
+- Adjust Reason: uint8 bitfield (Manual Update, External Reference, Time Zone, DST)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import msgspec
+
+from ...types.gatt_enums import DayOfWeek
+from ..context import CharacteristicContext
+from .base import BaseCharacteristic
+from .utils import IEEE11073Parser
+
+# Bluetooth SIG Current Time characteristic constants
+CURRENT_TIME_LENGTH = 10  # Total characteristic length in bytes
+DAY_OF_WEEK_MAX = 7  # Maximum day of week value (0=unknown, 1-7=Mon-Sun)
+FRACTIONS256_MAX = 255  # Maximum fractions256 value
+ADJUST_REASON_MAX = 255  # Maximum adjust reason value
+
+
+class CurrentTimeData(msgspec.Struct):
+    """Current Time characteristic data structure."""
+
+    date_time: datetime | None  # None if year/month/day are 0 (unknown)
+    day_of_week: DayOfWeek
+    fractions256: int  # 0-255 (1/256 fractions of a second)
+    adjust_reason: int  # Bitfield of AdjustReason flags
+
+
+class CurrentTimeCharacteristic(BaseCharacteristic):
+    """Current Time characteristic (0x2A2B).
+
+    Represents exact time with date, time, day of week, sub-second precision,
+    and reasons for time adjustment.
+
+    Structure (10 bytes):
+    - Year: uint16 (1582-9999, 0=unknown)
+    - Month: uint8 (1-12, 0=unknown)
+    - Day: uint8 (1-31, 0=unknown)
+    - Hours: uint8 (0-23)
+    - Minutes: uint8 (0-59)
+    - Seconds: uint8 (0-59)
+    - Day of Week: uint8 (0=unknown, 1=Monday...7=Sunday)
+    - Fractions256: uint8 (0-255, representing 1/256 fractions of a second)
+    - Adjust Reason: uint8 bitfield
+    """
+
+    def decode_value(self, data: bytearray, ctx: CharacteristicContext | None = None) -> CurrentTimeData:
+        """Decode Current Time data from bytes.
+
+        Args:
+            data: Raw characteristic data (10 bytes)
+            ctx: Optional characteristic context
+
+        Returns:
+            CurrentTimeData with all time fields
+
+        Raises:
+            ValueError: If data is insufficient or contains invalid values
+
+        """
+        if len(data) < CURRENT_TIME_LENGTH:
+            raise ValueError(
+                f"Insufficient data for Current Time: expected {CURRENT_TIME_LENGTH} bytes, got {len(data)}"
+            )
+
+        # Parse Date Time (7 bytes) - handle unknown (0) values
+        year = int.from_bytes(data[0:2], "little")
+        month = data[2]
+        day = data[3]
+
+        # If year, month, or day is 0 (unknown), set date_time to None
+        if year == 0 or month == 0 or day == 0:
+            date_time = None
+        else:
+            date_time = IEEE11073Parser.parse_timestamp(data, 0)
+
+        # Parse Day of Week (1 byte)
+        day_of_week_raw = data[7]
+        if day_of_week_raw > DAY_OF_WEEK_MAX:
+            raise ValueError(f"Invalid day of week: {day_of_week_raw} (valid range: 0-{DAY_OF_WEEK_MAX})")
+        day_of_week = DayOfWeek(day_of_week_raw)
+
+        # Parse Fractions256 (1 byte)
+        fractions256 = data[8]
+
+        # Parse Adjust Reason (1 byte)
+        adjust_reason = data[9]
+
+        return CurrentTimeData(
+            date_time=date_time,
+            day_of_week=day_of_week,
+            fractions256=fractions256,
+            adjust_reason=adjust_reason,
+        )
+
+    def encode_value(self, data: CurrentTimeData) -> bytearray:
+        """Encode Current Time data to bytes.
+
+        Args:
+            data: CurrentTimeData to encode
+
+        Returns:
+            Encoded current time (10 bytes)
+
+        Raises:
+            ValueError: If data contains invalid values
+
+        """
+        result = bytearray()
+
+        # Encode Date Time (7 bytes)
+        if data.date_time is None:
+            # Unknown date/time: all zeros
+            result.extend(bytearray(IEEE11073Parser.TIMESTAMP_LENGTH))
+        else:
+            result.extend(IEEE11073Parser.encode_timestamp(data.date_time))
+
+        # Encode Day of Week (1 byte)
+        day_of_week_value = int(data.day_of_week)
+        if day_of_week_value > DAY_OF_WEEK_MAX:
+            raise ValueError(f"Invalid day of week: {day_of_week_value} (valid range: 0-{DAY_OF_WEEK_MAX})")
+        result.append(day_of_week_value)
+
+        # Encode Fractions256 (1 byte)
+        if data.fractions256 > FRACTIONS256_MAX:
+            raise ValueError(f"Invalid fractions256: {data.fractions256} (valid range: 0-{FRACTIONS256_MAX})")
+        result.append(data.fractions256)
+
+        # Encode Adjust Reason (1 byte)
+        if data.adjust_reason > ADJUST_REASON_MAX:
+            raise ValueError(f"Invalid adjust_reason: {data.adjust_reason} (valid range: 0-{ADJUST_REASON_MAX})")
+        result.append(data.adjust_reason)
+
+        return result

--- a/src/bluetooth_sig/gatt/characteristics/new_alert.py
+++ b/src/bluetooth_sig/gatt/characteristics/new_alert.py
@@ -1,0 +1,113 @@
+"""New Alert characteristic (0x2A46) implementation.
+
+Represents a new alert with category, count, and optional text information.
+Used by Alert Notification Service (0x1811).
+
+Based on Bluetooth SIG GATT Specification:
+- New Alert: Variable length (Category ID + Number of New Alert + Text String)
+"""
+
+from __future__ import annotations
+
+import msgspec
+
+from ...types import (
+    ALERT_TEXT_MAX_LENGTH,
+    AlertCategoryID,
+    validate_category_id,
+)
+from ..context import CharacteristicContext
+from .base import BaseCharacteristic
+from .utils import DataParser
+
+
+class NewAlertData(msgspec.Struct):
+    """New Alert characteristic data structure."""
+
+    category_id: AlertCategoryID
+    number_of_new_alert: int  # 0-255
+    text_string_information: str  # 0-18 characters
+
+
+class NewAlertCharacteristic(BaseCharacteristic):
+    """New Alert characteristic (0x2A46).
+
+    Represents the category, count, and brief text for a new alert.
+
+    Structure (variable length):
+    - Category ID: uint8 (0=Simple Alert, 1=Email, etc.)
+    - Number of New Alert: uint8 (0-255, count of new alerts)
+    - Text String Information: utf8s (0-18 characters, optional brief text)
+
+    Used by Alert Notification Service (0x1811).
+    """
+
+    def decode_value(self, data: bytearray, ctx: CharacteristicContext | None = None) -> NewAlertData:
+        """Decode New Alert data from bytes.
+
+        Args:
+            data: Raw characteristic data (minimum 2 bytes)
+            ctx: Optional characteristic context
+
+        Returns:
+            NewAlertData with all fields
+
+        Raises:
+            ValueError: If data is insufficient or contains invalid values
+
+        """
+        if len(data) < 2:
+            raise ValueError(f"Insufficient data for New Alert: expected minimum 2 bytes, got {len(data)}")
+
+        # Parse Category ID (1 byte)
+        category_id_raw = DataParser.parse_int8(data, 0, signed=False)
+        category_id = validate_category_id(category_id_raw)
+
+        # Parse Number of New Alert (1 byte)
+        number_of_new_alert = DataParser.parse_int8(data, 1, signed=False)
+
+        # Parse Text String Information (remaining bytes, max ALERT_TEXT_MAX_LENGTH characters)
+        text_string_information = ""
+        if len(data) > 2:
+            text_bytes = data[2:]
+            if len(text_bytes) > ALERT_TEXT_MAX_LENGTH:
+                raise ValueError(f"Text string too long: {len(text_bytes)} bytes (max {ALERT_TEXT_MAX_LENGTH})")
+            text_string_information = text_bytes.decode("utf-8", errors="replace")
+
+        return NewAlertData(
+            category_id=category_id,
+            number_of_new_alert=number_of_new_alert,
+            text_string_information=text_string_information,
+        )
+
+    def encode_value(self, data: NewAlertData) -> bytearray:
+        """Encode New Alert data to bytes.
+
+        Args:
+            data: NewAlertData to encode
+
+        Returns:
+            Encoded new alert (variable length)
+
+        Raises:
+            ValueError: If data contains invalid values
+
+        """
+        result = bytearray()
+
+        # Encode Category ID (1 byte)
+        category_id_value = int(data.category_id)
+        validate_category_id(category_id_value)  # Validate the category ID value
+        result.append(category_id_value)
+
+        # Encode Number of New Alert (1 byte)
+        result.append(data.number_of_new_alert)
+
+        # Encode Text String Information (utf-8)
+        if data.text_string_information:
+            text_bytes = data.text_string_information.encode("utf-8")
+            if len(text_bytes) > ALERT_TEXT_MAX_LENGTH:
+                raise ValueError(f"Text string too long: {len(text_bytes)} bytes (max {ALERT_TEXT_MAX_LENGTH})")
+            result.extend(text_bytes)
+
+        return result

--- a/src/bluetooth_sig/gatt/characteristics/reference_time_information.py
+++ b/src/bluetooth_sig/gatt/characteristics/reference_time_information.py
@@ -1,0 +1,174 @@
+"""Reference Time Information characteristic (0x2A14) implementation.
+
+Provides information about the reference time source, including its type,
+accuracy, and time since last update.
+
+Based on Bluetooth SIG GATT Specification:
+- Reference Time Information: 4 bytes (Time Source + Time Accuracy + Days Since Update + Hours Since Update)
+- Time Source: uint8 (0=Unknown, 1=NTP, 2=GPS, etc.)
+- Time Accuracy: uint8 (0-253 in 125ms steps, 254=out of range, 255=unknown)
+- Days Since Update: uint8 (0-254, 255 means >=255 days)
+- Hours Since Update: uint8 (0-23, 255 means >=255 days)
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+import msgspec
+
+from ..context import CharacteristicContext
+from .base import BaseCharacteristic
+from .utils import DataParser
+
+# Bluetooth SIG Reference Time Information characteristic constants
+REFERENCE_TIME_INFO_LENGTH = 4  # Total characteristic length in bytes
+TIME_SOURCE_MAX = 7  # Maximum valid time source value (0-7)
+HOURS_SINCE_UPDATE_MAX = 23  # Maximum valid hours value (0-23)
+HOURS_SINCE_UPDATE_OUT_OF_RANGE = 255  # Special value indicating >=255 days
+
+
+class TimeSource(IntEnum):
+    """Time source enumeration per Bluetooth SIG specification."""
+
+    UNKNOWN = 0
+    NETWORK_TIME_PROTOCOL = 1
+    GPS = 2
+    RADIO_TIME_SIGNAL = 3
+    MANUAL = 4
+    ATOMIC_CLOCK = 5
+    CELLULAR_NETWORK = 6
+    NOT_SYNCHRONIZED = 7
+
+
+class ReferenceTimeInformationData(msgspec.Struct):
+    """Reference Time Information characteristic data structure."""
+
+    time_source: TimeSource
+    time_accuracy: int  # 0-253 (in 125ms steps), 254=out of range, 255=unknown
+    days_since_update: int  # 0-254, 255 means >=255 days
+    hours_since_update: int  # 0-23, 255 means >=255 days
+
+
+class ReferenceTimeInformationCharacteristic(BaseCharacteristic):
+    """Reference Time Information characteristic (0x2A14).
+
+    Represents information about the reference time source including type,
+    accuracy, and time elapsed since last synchronization.
+
+    Structure (4 bytes):
+    - Time Source: uint8 (0=Unknown, 1=NTP, 2=GPS, 3=Radio, 4=Manual, 5=Atomic, 6=Cellular, 7=Not Sync)
+    - Time Accuracy: uint8 (0-253 in 125ms steps, 254=out of range >31.625s, 255=unknown)
+    - Days Since Update: uint8 (0-254 days, 255 means >=255 days)
+    - Hours Since Update: uint8 (0-23 hours, 255 means >=255 days)
+
+    Used by Current Time Service (0x1805).
+    """
+
+    def decode_value(self, data: bytearray, ctx: CharacteristicContext | None = None) -> ReferenceTimeInformationData:
+        """Decode Reference Time Information data from bytes.
+
+        Args:
+            data: Raw characteristic data (4 bytes)
+            ctx: Optional characteristic context
+
+        Returns:
+            ReferenceTimeInformationData with all fields
+
+        Raises:
+            ValueError: If data is insufficient or contains invalid values
+
+        """
+        if len(data) < REFERENCE_TIME_INFO_LENGTH:
+            raise ValueError(
+                f"Insufficient data for Reference Time Information: "
+                f"expected {REFERENCE_TIME_INFO_LENGTH} bytes, got {len(data)}"
+            )
+
+        # Parse Time Source (1 byte)
+        time_source_raw = DataParser.parse_int8(data, 0, signed=False)
+        time_source = _validate_time_source(time_source_raw)
+
+        # Parse Time Accuracy (1 byte) - no validation needed, all values 0-255 valid
+        time_accuracy = DataParser.parse_int8(data, 1, signed=False)
+
+        # Parse Days Since Update (1 byte) - no validation needed, all values 0-255 valid
+        days_since_update = DataParser.parse_int8(data, 2, signed=False)
+
+        # Parse Hours Since Update (1 byte)
+        hours_since_update = DataParser.parse_int8(data, 3, signed=False)
+        _validate_hours_since_update(hours_since_update)
+
+        return ReferenceTimeInformationData(
+            time_source=time_source,
+            time_accuracy=time_accuracy,
+            days_since_update=days_since_update,
+            hours_since_update=hours_since_update,
+        )
+
+    def encode_value(self, data: ReferenceTimeInformationData) -> bytearray:
+        """Encode Reference Time Information data to bytes.
+
+        Args:
+            data: ReferenceTimeInformationData to encode
+
+        Returns:
+            Encoded reference time information (4 bytes)
+
+        Raises:
+            ValueError: If data contains invalid values
+
+        """
+        result = bytearray()
+
+        # Encode Time Source (1 byte)
+        time_source_value = int(data.time_source)
+        _validate_time_source(time_source_value)  # Validate before encoding
+        result.append(time_source_value)
+
+        # Encode Time Accuracy (1 byte) - all values 0-255 valid
+        result.append(data.time_accuracy)
+
+        # Encode Days Since Update (1 byte) - all values 0-255 valid
+        result.append(data.days_since_update)
+
+        # Encode Hours Since Update (1 byte)
+        _validate_hours_since_update(data.hours_since_update)
+        result.append(data.hours_since_update)
+
+        return result
+
+
+def _validate_time_source(time_source_raw: int) -> TimeSource:
+    """Validate time source value.
+
+    Args:
+        time_source_raw: Raw time source value (0-255)
+
+    Returns:
+        TimeSource enum value
+
+    Raises:
+        ValueError: If time source is in reserved range (8-254)
+
+    """
+    if TIME_SOURCE_MAX < time_source_raw < HOURS_SINCE_UPDATE_OUT_OF_RANGE:
+        raise ValueError(f"Invalid time source: {time_source_raw} (valid range: 0-{TIME_SOURCE_MAX})")
+    return TimeSource(time_source_raw) if time_source_raw <= TIME_SOURCE_MAX else TimeSource.UNKNOWN
+
+
+def _validate_hours_since_update(hours: int) -> None:
+    """Validate hours since update value.
+
+    Args:
+        hours: Hours since update value (0-255)
+
+    Raises:
+        ValueError: If hours is invalid (24-254)
+
+    """
+    if hours > HOURS_SINCE_UPDATE_MAX and hours != HOURS_SINCE_UPDATE_OUT_OF_RANGE:
+        raise ValueError(
+            f"Invalid hours since update: {hours} "
+            f"(valid range: 0-{HOURS_SINCE_UPDATE_MAX} or {HOURS_SINCE_UPDATE_OUT_OF_RANGE} for >=255 days)"
+        )

--- a/src/bluetooth_sig/gatt/characteristics/supported_new_alert_category.py
+++ b/src/bluetooth_sig/gatt/characteristics/supported_new_alert_category.py
@@ -1,0 +1,62 @@
+"""Supported New Alert Category characteristic (0x2A47) implementation.
+
+Represents which alert categories the server supports for new alerts.
+Used by Alert Notification Service (0x1811).
+
+Based on Bluetooth SIG GATT Specification:
+- Supported New Alert Category: 2 bytes (16-bit Category ID Bit Mask)
+"""
+
+from __future__ import annotations
+
+from ...types import AlertCategoryBitMask
+from ..context import CharacteristicContext
+from .base import BaseCharacteristic
+from .utils import DataParser
+
+
+class SupportedNewAlertCategoryCharacteristic(BaseCharacteristic):
+    """Supported New Alert Category characteristic (0x2A47).
+
+    Represents which alert categories the server supports for new alerts
+    using a 16-bit bitmask.
+
+    Structure (2 bytes):
+    - Category ID Bit Mask: uint16 (bit 0=Simple Alert, bit 1=Email, etc.)
+      Bits 10-15 reserved for future use
+
+    Used by Alert Notification Service (0x1811).
+    """
+
+    def decode_value(self, data: bytearray, ctx: CharacteristicContext | None = None) -> AlertCategoryBitMask:
+        """Decode Supported New Alert Category data from bytes.
+
+        Args:
+            data: Raw characteristic data (2 bytes)
+            ctx: Optional characteristic context
+
+        Returns:
+            AlertCategoryBitMask flags
+
+        Raises:
+            ValueError: If data is insufficient
+
+        """
+        if len(data) < 2:
+            raise ValueError(f"Insufficient data for Supported New Alert Category: expected 2 bytes, got {len(data)}")
+
+        mask_value = DataParser.parse_int16(data, 0, signed=False)
+        return AlertCategoryBitMask(mask_value)
+
+    def encode_value(self, data: AlertCategoryBitMask | int) -> bytearray:
+        """Encode Supported New Alert Category data to bytes.
+
+        Args:
+            data: AlertCategoryBitMask or int value
+
+        Returns:
+            Encoded supported new alert category (2 bytes)
+
+        """
+        int_value = int(data) if isinstance(data, AlertCategoryBitMask) else data
+        return DataParser.encode_int16(int_value, signed=False)

--- a/src/bluetooth_sig/gatt/characteristics/supported_unread_alert_category.py
+++ b/src/bluetooth_sig/gatt/characteristics/supported_unread_alert_category.py
@@ -1,0 +1,64 @@
+"""Supported Unread Alert Category characteristic (0x2A48) implementation.
+
+Represents which alert categories the server supports for unread alerts.
+Used by Alert Notification Service (0x1811).
+
+Based on Bluetooth SIG GATT Specification:
+- Supported Unread Alert Category: 2 bytes (16-bit Category ID Bit Mask)
+"""
+
+from __future__ import annotations
+
+from ...types import AlertCategoryBitMask
+from ..context import CharacteristicContext
+from .base import BaseCharacteristic
+from .utils import DataParser
+
+
+class SupportedUnreadAlertCategoryCharacteristic(BaseCharacteristic):
+    """Supported Unread Alert Category characteristic (0x2A48).
+
+    Represents which alert categories the server supports for unread alerts
+    using a 16-bit bitmask.
+
+    Structure (2 bytes):
+    - Category ID Bit Mask: uint16 (bit 0=Simple Alert, bit 1=Email, etc.)
+      Bits 10-15 reserved for future use
+
+    Used by Alert Notification Service (0x1811).
+    """
+
+    def decode_value(self, data: bytearray, ctx: CharacteristicContext | None = None) -> AlertCategoryBitMask:
+        """Decode Supported Unread Alert Category data from bytes.
+
+        Args:
+            data: Raw characteristic data (2 bytes)
+            ctx: Optional characteristic context
+
+        Returns:
+            AlertCategoryBitMask flags
+
+        Raises:
+            ValueError: If data is insufficient
+
+        """
+        if len(data) < 2:
+            raise ValueError(
+                f"Insufficient data for Supported Unread Alert Category: expected 2 bytes, got {len(data)}"
+            )
+
+        mask_value = DataParser.parse_int16(data, 0, signed=False)
+        return AlertCategoryBitMask(mask_value)
+
+    def encode_value(self, data: AlertCategoryBitMask | int) -> bytearray:
+        """Encode Supported Unread Alert Category data to bytes.
+
+        Args:
+            data: AlertCategoryBitMask or int value
+
+        Returns:
+            Encoded supported unread alert category (2 bytes)
+
+        """
+        int_value = int(data) if isinstance(data, AlertCategoryBitMask) else data
+        return DataParser.encode_int16(int_value, signed=False)

--- a/src/bluetooth_sig/gatt/characteristics/unread_alert_status.py
+++ b/src/bluetooth_sig/gatt/characteristics/unread_alert_status.py
@@ -1,0 +1,94 @@
+"""Unread Alert Status characteristic (0x2A45) implementation.
+
+Represents the number of unread alerts in a specific category.
+Used by Alert Notification Service (0x1811).
+
+Based on Bluetooth SIG GATT Specification:
+- Unread Alert Status: 2 bytes (Category ID + Unread Count)
+"""
+
+from __future__ import annotations
+
+import msgspec
+
+from ...types import (
+    AlertCategoryID,
+    validate_category_id,
+)
+from ..context import CharacteristicContext
+from .base import BaseCharacteristic
+from .utils import DataParser
+
+
+class UnreadAlertStatusData(msgspec.Struct):
+    """Unread Alert Status characteristic data structure."""
+
+    category_id: AlertCategoryID
+    unread_count: int  # 0-254, 255 means >254
+
+
+class UnreadAlertStatusCharacteristic(BaseCharacteristic):
+    """Unread Alert Status characteristic (0x2A45).
+
+    Represents the number of unread alerts in a specific category.
+
+    Structure (2 bytes):
+    - Category ID: uint8 (0=Simple Alert, 1=Email, etc.)
+    - Unread Count: uint8 (0-254, 255 means more than 254 unread alerts)
+
+    Used by Alert Notification Service (0x1811).
+    """
+
+    def decode_value(self, data: bytearray, ctx: CharacteristicContext | None = None) -> UnreadAlertStatusData:
+        """Decode Unread Alert Status data from bytes.
+
+        Args:
+            data: Raw characteristic data (2 bytes)
+            ctx: Optional characteristic context
+
+        Returns:
+            UnreadAlertStatusData with all fields
+
+        Raises:
+            ValueError: If data is insufficient or contains invalid values
+
+        """
+        if len(data) < 2:
+            raise ValueError(f"Insufficient data for Unread Alert Status: expected 2 bytes, got {len(data)}")
+
+        # Parse Category ID (1 byte)
+        category_id_raw = DataParser.parse_int8(data, 0, signed=False)
+        category_id = validate_category_id(category_id_raw)
+
+        # Parse Unread Count (1 byte)
+        unread_count = DataParser.parse_int8(data, 1, signed=False)
+
+        return UnreadAlertStatusData(
+            category_id=category_id,
+            unread_count=unread_count,
+        )
+
+    def encode_value(self, data: UnreadAlertStatusData) -> bytearray:
+        """Encode Unread Alert Status data to bytes.
+
+        Args:
+            data: UnreadAlertStatusData to encode
+
+        Returns:
+            Encoded unread alert status (2 bytes)
+
+        Raises:
+            ValueError: If data contains invalid values
+
+        """
+        result = bytearray()
+
+        # Encode Category ID (1 byte)
+        category_id_value = int(data.category_id)
+        validate_category_id(category_id_value)  # Validate the category ID value
+        result.append(category_id_value)
+
+        # Encode Unread Count (1 byte)
+        result.append(data.unread_count)
+
+        return result

--- a/src/bluetooth_sig/types/__init__.py
+++ b/src/bluetooth_sig/types/__init__.py
@@ -14,6 +14,20 @@ from .advertising import (
     PDUFlags,
     PDUType,
 )
+from .alert import (
+    ALERT_CATEGORY_DEFINED_MAX,
+    ALERT_CATEGORY_RESERVED_MAX,
+    ALERT_CATEGORY_RESERVED_MIN,
+    ALERT_CATEGORY_SERVICE_SPECIFIC_MIN,
+    ALERT_COMMAND_MAX,
+    ALERT_TEXT_MAX_LENGTH,
+    UNREAD_COUNT_MAX,
+    UNREAD_COUNT_MORE_THAN_MAX,
+    AlertCategoryBitMask,
+    AlertCategoryID,
+    AlertNotificationCommandID,
+    validate_category_id,
+)
 from .base_types import SIGInfo
 from .battery import BatteryChargeLevel, BatteryChargeState, BatteryChargingType, BatteryFaultReason
 from .context import CharacteristicContext, DeviceInfo
@@ -51,6 +65,18 @@ from .units import (
 # Import them directly: from bluetooth_sig.types.device_types import DeviceService, DeviceEncryption
 
 __all__ = [
+    "ALERT_CATEGORY_DEFINED_MAX",
+    "ALERT_CATEGORY_RESERVED_MIN",
+    "ALERT_CATEGORY_RESERVED_MAX",
+    "ALERT_CATEGORY_SERVICE_SPECIFIC_MIN",
+    "ALERT_COMMAND_MAX",
+    "ALERT_TEXT_MAX_LENGTH",
+    "UNREAD_COUNT_MAX",
+    "UNREAD_COUNT_MORE_THAN_MAX",
+    "AlertCategoryBitMask",
+    "AlertCategoryID",
+    "AlertNotificationCommandID",
+    "validate_category_id",
     "AngleUnit",
     "BatteryChargeLevel",
     "BatteryChargeState",

--- a/src/bluetooth_sig/types/alert.py
+++ b/src/bluetooth_sig/types/alert.py
@@ -1,0 +1,99 @@
+"""Alert Notification types and enumerations.
+
+Provides common types used across Alert Notification Service characteristics.
+Based on Bluetooth SIG GATT Specification for Alert Notification Service (0x1811).
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum, IntFlag
+
+# Alert Category ID value ranges
+ALERT_CATEGORY_DEFINED_MAX = 9  # 0-9 are defined categories
+ALERT_CATEGORY_RESERVED_MIN = 10  # 10-250 are reserved
+ALERT_CATEGORY_RESERVED_MAX = 250
+ALERT_CATEGORY_SERVICE_SPECIFIC_MIN = 251  # 251-255 are service-specific
+
+# Alert text constraints
+ALERT_TEXT_MAX_LENGTH = 18  # Maximum UTF-8 text length in bytes
+
+# Unread count special values
+UNREAD_COUNT_MAX = 254  # 0-254 explicit count
+UNREAD_COUNT_MORE_THAN_MAX = 255  # 255 means >254 unread
+
+# Control point command range
+ALERT_COMMAND_MAX = 5  # Valid command IDs are 0-5
+
+
+class AlertCategoryID(IntEnum):
+    """Alert category enumeration per Bluetooth SIG specification.
+
+    Values 0-9 are defined, 10-250 reserved, 251-255 service-specific.
+    """
+
+    SIMPLE_ALERT = 0
+    EMAIL = 1
+    NEWS = 2
+    CALL = 3
+    MISSED_CALL = 4
+    SMS_MMS = 5
+    VOICE_MAIL = 6
+    SCHEDULE = 7
+    HIGH_PRIORITIZED_ALERT = 8
+    INSTANT_MESSAGE = 9
+
+
+class AlertCategoryBitMask(IntFlag):
+    """Alert category bit mask flags.
+
+    Each bit represents support for a specific alert category.
+    Bits 10-15 are reserved for future use.
+    """
+
+    SIMPLE_ALERT = 1 << 0
+    EMAIL = 1 << 1
+    NEWS = 1 << 2
+    CALL = 1 << 3
+    MISSED_CALL = 1 << 4
+    SMS_MMS = 1 << 5
+    VOICE_MAIL = 1 << 6
+    SCHEDULE = 1 << 7
+    HIGH_PRIORITIZED_ALERT = 1 << 8
+    INSTANT_MESSAGE = 1 << 9
+
+
+class AlertNotificationCommandID(IntEnum):
+    """Alert Notification Control Point command enumeration."""
+
+    ENABLE_NEW_ALERT = 0
+    ENABLE_UNREAD_STATUS = 1
+    DISABLE_NEW_ALERT = 2
+    DISABLE_UNREAD_STATUS = 3
+    NOTIFY_NEW_ALERT_IMMEDIATELY = 4
+    NOTIFY_UNREAD_STATUS_IMMEDIATELY = 5
+
+
+def validate_category_id(category_id_raw: int) -> AlertCategoryID:
+    """Validate and convert raw category ID value.
+
+    Args:
+        category_id_raw: Raw category ID value (0-255)
+
+    Returns:
+        AlertCategoryID enum value
+
+    Raises:
+        ValueError: If category ID is in reserved range (10-250)
+
+    """
+    if not (category_id_raw <= ALERT_CATEGORY_DEFINED_MAX or category_id_raw >= ALERT_CATEGORY_SERVICE_SPECIFIC_MIN):
+        raise ValueError(
+            f"Invalid category ID: {category_id_raw} "
+            f"(valid: 0-{ALERT_CATEGORY_DEFINED_MAX} or "
+            f"{ALERT_CATEGORY_SERVICE_SPECIFIC_MIN}-255)"
+        )
+    return (
+        AlertCategoryID(category_id_raw)
+        if category_id_raw <= ALERT_CATEGORY_DEFINED_MAX
+        else AlertCategoryID.SIMPLE_ALERT
+    )

--- a/src/bluetooth_sig/types/gatt_enums.py
+++ b/src/bluetooth_sig/types/gatt_enums.py
@@ -7,7 +7,37 @@ alternatives.
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import Enum, IntEnum
+
+
+class DayOfWeek(IntEnum):
+    """Day of week enumeration per ISO 8601.
+
+    Used by Current Time Service and other time-related characteristics.
+    Values follow ISO 8601 standard (Monday=1, Sunday=7, Unknown=0).
+    """
+
+    UNKNOWN = 0
+    MONDAY = 1
+    TUESDAY = 2
+    WEDNESDAY = 3
+    THURSDAY = 4
+    FRIDAY = 5
+    SATURDAY = 6
+    SUNDAY = 7
+
+
+class AdjustReason(IntEnum):
+    """Time adjustment reason flags.
+
+    Used by Current Time Service to indicate why time was adjusted.
+    Can be combined as bitfield flags.
+    """
+
+    MANUAL_TIME_UPDATE = 1 << 0  # Bit 0
+    EXTERNAL_REFERENCE_TIME_UPDATE = 1 << 1  # Bit 1
+    CHANGE_OF_TIME_ZONE = 1 << 2  # Bit 2
+    CHANGE_OF_DST = 1 << 3  # Bit 3
 
 
 class GattProperty(Enum):
@@ -264,6 +294,12 @@ class CharacteristicName(Enum):
     ALERT_STATUS = "Alert Status"
     RINGER_SETTING = "Ringer Setting"
     RINGER_CONTROL_POINT = "Ringer Control Point"
+    # Alert Notification Service characteristics
+    NEW_ALERT = "New Alert"
+    SUPPORTED_NEW_ALERT_CATEGORY = "Supported New Alert Category"
+    UNREAD_ALERT_STATUS = "Unread Alert Status"
+    SUPPORTED_UNREAD_ALERT_CATEGORY = "Supported Unread Alert Category"
+    ALERT_NOTIFICATION_CONTROL_POINT = "Alert Notification Control Point"
 
 
 class ServiceName(Enum):

--- a/tests/gatt/characteristics/test_alert_level.py
+++ b/tests/gatt/characteristics/test_alert_level.py
@@ -1,0 +1,86 @@
+"""Tests for Alert Level characteristic (0x2A06)."""
+
+from __future__ import annotations
+
+import pytest
+
+from bluetooth_sig.gatt.characteristics.alert_level import AlertLevel, AlertLevelCharacteristic
+from tests.gatt.characteristics.test_characteristic_common import CharacteristicTestData, CommonCharacteristicTests
+
+
+class TestAlertLevelCharacteristic(CommonCharacteristicTests):
+    """Test suite for Alert Level characteristic.
+
+    Inherits behavioral tests from CommonCharacteristicTests.
+    Adds alert-specific edge cases and enum validation.
+    """
+
+    @pytest.fixture
+    def characteristic(self) -> AlertLevelCharacteristic:
+        """Return an Alert Level characteristic instance."""
+        return AlertLevelCharacteristic()
+
+    @pytest.fixture
+    def expected_uuid(self) -> str:
+        """Return the expected UUID for Alert Level characteristic."""
+        return "2A06"
+
+    @pytest.fixture
+    def valid_test_data(self) -> list[CharacteristicTestData]:
+        """Return valid test data for all alert levels."""
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x00]), expected_value=AlertLevel.NO_ALERT, description="No Alert"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x01]), expected_value=AlertLevel.MILD_ALERT, description="Mild Alert"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x02]), expected_value=AlertLevel.HIGH_ALERT, description="High Alert"
+            ),
+        ]
+
+    def test_alert_level_reserved_values_rejected(self, characteristic: AlertLevelCharacteristic) -> None:
+        """Test that reserved values (0x03-0xFF) are rejected."""
+        # Test reserved value 0x03
+        result = characteristic.parse_value(bytearray([0x03]))
+        assert not result.parse_success
+        assert "reserved" in result.error_message.lower() or "invalid" in result.error_message.lower()
+
+        # Test higher reserved value 0xFF
+        result = characteristic.parse_value(bytearray([0xFF]))
+        assert not result.parse_success
+        assert "reserved" in result.error_message.lower() or "invalid" in result.error_message.lower()
+
+    @pytest.mark.parametrize(
+        "alert_level",
+        [AlertLevel.NO_ALERT, AlertLevel.MILD_ALERT, AlertLevel.HIGH_ALERT],
+    )
+    def test_alert_level_encoding_enum(self, characteristic: AlertLevelCharacteristic, alert_level: AlertLevel) -> None:
+        """Test encoding alert levels from enum values."""
+        encoded = characteristic.encode_value(alert_level)
+        assert len(encoded) == 1
+        assert encoded[0] == alert_level.value
+
+    @pytest.mark.parametrize(
+        "alert_int",
+        [0, 1, 2],
+    )
+    def test_alert_level_encoding_int(self, characteristic: AlertLevelCharacteristic, alert_int: int) -> None:
+        """Test encoding alert levels from integer values."""
+        encoded = characteristic.encode_value(alert_int)
+        assert len(encoded) == 1
+        assert encoded[0] == alert_int
+
+    def test_alert_level_roundtrip(self, characteristic: AlertLevelCharacteristic) -> None:
+        """Test that encode/decode are inverse operations."""
+        for level in [AlertLevel.NO_ALERT, AlertLevel.MILD_ALERT, AlertLevel.HIGH_ALERT]:
+            encoded = characteristic.encode_value(level)
+            decoded = characteristic.decode_value(encoded)
+            assert decoded == level
+
+    def test_alert_level_enum_values(self) -> None:
+        """Test AlertLevel enum has correct values per spec."""
+        assert AlertLevel.NO_ALERT.value == 0x00
+        assert AlertLevel.MILD_ALERT.value == 0x01
+        assert AlertLevel.HIGH_ALERT.value == 0x02

--- a/tests/gatt/characteristics/test_alert_notification_control_point.py
+++ b/tests/gatt/characteristics/test_alert_notification_control_point.py
@@ -1,0 +1,99 @@
+"""Tests for Alert Notification Control Point characteristic (0x2A44)."""
+
+from __future__ import annotations
+
+import pytest
+
+from bluetooth_sig.gatt.characteristics.alert_notification_control_point import (
+    AlertNotificationControlPointCharacteristic,
+    AlertNotificationControlPointData,
+)
+from bluetooth_sig.types import AlertCategoryID, AlertNotificationCommandID
+from tests.gatt.characteristics.test_characteristic_common import CharacteristicTestData, CommonCharacteristicTests
+
+
+class TestAlertNotificationControlPointCharacteristic(CommonCharacteristicTests):
+    """Test suite for Alert Notification Control Point characteristic."""
+
+    @pytest.fixture
+    def characteristic(self) -> AlertNotificationControlPointCharacteristic:
+        """Return an Alert Notification Control Point characteristic instance."""
+        return AlertNotificationControlPointCharacteristic()
+
+    @pytest.fixture
+    def expected_uuid(self) -> str:
+        """Return the expected UUID."""
+        return "2A44"
+
+    @pytest.fixture
+    def valid_test_data(self) -> list[CharacteristicTestData]:
+        """Return valid test data (Enable new email alerts)."""
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x00, 0x01]),  # Enable New Alert, Email category
+                expected_value=AlertNotificationControlPointData(
+                    command_id=AlertNotificationCommandID.ENABLE_NEW_ALERT, category_id=AlertCategoryID.EMAIL
+                ),
+                description="Enable new email alerts",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x04, 0x03]),  # Notify New Alert Immediately, Call category
+                expected_value=AlertNotificationControlPointData(
+                    command_id=AlertNotificationCommandID.NOTIFY_NEW_ALERT_IMMEDIATELY, category_id=AlertCategoryID.CALL
+                ),
+                description="Notify new call alerts immediately",
+            ),
+        ]
+
+    @pytest.mark.parametrize(
+        "command_id,expected_enum",
+        [
+            (0, AlertNotificationCommandID.ENABLE_NEW_ALERT),
+            (1, AlertNotificationCommandID.ENABLE_UNREAD_STATUS),
+            (2, AlertNotificationCommandID.DISABLE_NEW_ALERT),
+            (3, AlertNotificationCommandID.DISABLE_UNREAD_STATUS),
+            (4, AlertNotificationCommandID.NOTIFY_NEW_ALERT_IMMEDIATELY),
+            (5, AlertNotificationCommandID.NOTIFY_UNREAD_STATUS_IMMEDIATELY),
+        ],
+    )
+    def test_all_command_ids(
+        self,
+        characteristic: AlertNotificationControlPointCharacteristic,
+        command_id: int,
+        expected_enum: AlertNotificationCommandID,
+    ) -> None:
+        """Test all valid command IDs."""
+        data = bytearray([command_id, 0x00])
+        result = characteristic.decode_value(data)
+        assert result.command_id == expected_enum
+
+    def test_invalid_command_id(self, characteristic: AlertNotificationControlPointCharacteristic) -> None:
+        """Test that invalid command IDs are rejected."""
+        data = bytearray([0x06, 0x00])  # 6 is reserved
+        result = characteristic.parse_value(data)
+        assert not result.parse_success
+        assert "command id" in result.error_message.lower()
+
+    def test_invalid_category_id(self, characteristic: AlertNotificationControlPointCharacteristic) -> None:
+        """Test that invalid category IDs are rejected."""
+        data = bytearray([0x00, 0x0A])  # 10 is reserved
+        result = characteristic.parse_value(data)
+        assert not result.parse_success
+        assert "category id" in result.error_message.lower()
+
+    def test_notify_immediately_command(self, characteristic: AlertNotificationControlPointCharacteristic) -> None:
+        """Test notify immediately command."""
+        data = bytearray([0x04, 0x03])  # Notify New Alert Immediately, Call category
+        result = characteristic.decode_value(data)
+        assert result.command_id == AlertNotificationCommandID.NOTIFY_NEW_ALERT_IMMEDIATELY
+        assert result.category_id == AlertCategoryID.CALL
+
+    def test_roundtrip(self, characteristic: AlertNotificationControlPointCharacteristic) -> None:
+        """Test encode/decode roundtrip."""
+        original = AlertNotificationControlPointData(
+            command_id=AlertNotificationCommandID.DISABLE_UNREAD_STATUS, category_id=AlertCategoryID.SMS_MMS
+        )
+        encoded = characteristic.encode_value(original)
+        decoded = characteristic.decode_value(encoded)
+        assert decoded.command_id == original.command_id
+        assert decoded.category_id == original.category_id

--- a/tests/gatt/characteristics/test_ammonia_concentration.py
+++ b/tests/gatt/characteristics/test_ammonia_concentration.py
@@ -20,13 +20,20 @@ class TestAmmoniaConcentrationCharacteristic(CommonCharacteristicTests):
         return "2BCF"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid ammonia concentration test data."""
-        return CharacteristicTestData(
-            input_data=bytearray([0x34, 0x92]),  # IEEE 11073 SFLOAT little endian
-            expected_value=5640.0,  # Expected parsed concentration value
-            description="Valid ammonia concentration",
-        )
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x0A, 0x80]),  # 10 in IEEE 11073 SFLOAT
+                expected_value=10.0,
+                description="10 ppm ammonia concentration",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x64, 0x80]),  # 100 in IEEE 11073 SFLOAT
+                expected_value=100.0,
+                description="100 ppm ammonia concentration",
+            ),
+        ]
 
     def test_ammonia_concentration_parsing(self, characteristic: AmmoniaConcentrationCharacteristic) -> None:
         """Test ammonia concentration characteristic parsing."""

--- a/tests/gatt/characteristics/test_apparent_wind_direction.py
+++ b/tests/gatt/characteristics/test_apparent_wind_direction.py
@@ -23,15 +23,65 @@ class TestApparentWindDirectionCharacteristic(CommonCharacteristicTests):
         return "2A73"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid apparent wind direction test data."""
-        return CharacteristicTestData(
-            input_data=bytearray([0x10, 0x27]),
-            expected_value=100.0,  # 10000 * 0.01 = 100.0°
-            description="100° wind direction",
-        )
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x00, 0x00]),
+                expected_value=0.0,
+                description="0° (bow/forward)",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x28, 0x23]),
+                expected_value=90.0,
+                description="90° (starboard beam)",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x10, 0x27]),
+                expected_value=100.0,
+                description="100° wind direction",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x50, 0x46]),
+                expected_value=180.0,
+                description="180° (stern/aft)",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x9F, 0x8C]),
+                expected_value=359.99,
+                description="359.99° (maximum)",
+            ),
+        ]
 
     def test_apparent_wind_direction_parsing(self, characteristic: ApparentWindDirectionCharacteristic) -> None:
         """Test apparent wind direction characteristic parsing."""
         direction_data = bytearray([0x10, 0x27])  # 10000 * 0.01 = 100.0°
         assert characteristic.decode_value(direction_data) == 100.0
+
+    def test_apparent_wind_direction_cardinal_points(self, characteristic: ApparentWindDirectionCharacteristic) -> None:
+        """Test apparent wind direction cardinal points."""
+        # Bow (0°)
+        data_bow = bytearray([0x00, 0x00])
+        assert characteristic.decode_value(data_bow) == 0.0
+
+        # Starboard beam (90°)
+        data_starboard = bytearray([0x28, 0x23])  # 9000 * 0.01 = 90.0
+        assert characteristic.decode_value(data_starboard) == 90.0
+
+        # Stern (180°)
+        data_stern = bytearray([0x50, 0x46])  # 18000 * 0.01 = 180.0
+        assert characteristic.decode_value(data_stern) == 180.0
+
+        # Port beam (270°)
+        data_port = bytearray([0x78, 0x69])  # 27000 * 0.01 = 270.0
+        assert characteristic.decode_value(data_port) == 270.0
+
+    def test_apparent_wind_direction_boundary_values(self, characteristic: ApparentWindDirectionCharacteristic) -> None:
+        """Test boundary wind direction values."""
+        # Minimum (0°)
+        data_min = bytearray([0x00, 0x00])
+        assert characteristic.decode_value(data_min) == 0.0
+
+        # Maximum (359.99°)
+        data_max = bytearray([0x9F, 0x8C])  # 35999 * 0.01 = 359.99
+        assert characteristic.decode_value(data_max) == 359.99

--- a/tests/gatt/characteristics/test_apparent_wind_speed.py
+++ b/tests/gatt/characteristics/test_apparent_wind_speed.py
@@ -23,14 +23,48 @@ class TestApparentWindSpeedCharacteristic(CommonCharacteristicTests):
         return "2A72"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid apparent wind speed test data."""
-        return CharacteristicTestData(
-            input_data=bytearray([0x64, 0x00]), expected_value=1.0, description="1.0 m/s apparent wind speed"
-        )
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x00, 0x00]), expected_value=0.0, description="0.0 m/s (calm)"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x64, 0x00]), expected_value=1.0, description="1.0 m/s (light air)"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0xF4, 0x01]), expected_value=5.0, description="5.0 m/s (light breeze)"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0xDC, 0x05]), expected_value=15.0, description="15.0 m/s (strong breeze)"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0xFF, 0xFF]), expected_value=655.35, description="655.35 m/s (maximum)"
+            ),
+        ]
 
     def test_apparent_wind_speed_parsing(self, characteristic: ApparentWindSpeedCharacteristic) -> None:
         """Test apparent wind speed characteristic parsing."""
         # Test parsing similar to true wind
         speed_data = bytearray([0x64, 0x00])  # 100 * 0.01 = 1.0 m/s
         assert characteristic.decode_value(speed_data) == 1.0
+
+    def test_apparent_wind_speed_boundary_values(self, characteristic: ApparentWindSpeedCharacteristic) -> None:
+        """Test boundary apparent wind speed values."""
+        # Calm
+        data_min = bytearray([0x00, 0x00])
+        assert characteristic.decode_value(data_min) == 0.0
+
+        # Maximum
+        data_max = bytearray([0xFF, 0xFF])
+        assert characteristic.decode_value(data_max) == 655.35
+
+    def test_apparent_wind_speed_various_conditions(self, characteristic: ApparentWindSpeedCharacteristic) -> None:
+        """Test apparent wind speed under various conditions."""
+        # Light breeze (5 m/s)
+        data_light = bytearray([0xF4, 0x01])  # 500 * 0.01
+        assert characteristic.decode_value(data_light) == 5.0
+
+        # Strong breeze (15 m/s)
+        data_strong = bytearray([0xDC, 0x05])  # 1500 * 0.01
+        assert characteristic.decode_value(data_strong) == 15.0

--- a/tests/gatt/characteristics/test_barometric_pressure_trend.py
+++ b/tests/gatt/characteristics/test_barometric_pressure_trend.py
@@ -27,13 +27,30 @@ class TestBarometricPressureTrendCharacteristic(CommonCharacteristicTests):
         return "2AA3"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid barometric pressure trend test data."""
-        return CharacteristicTestData(
-            input_data=bytearray([1]),
-            expected_value=BarometricPressureTrend.CONTINUOUSLY_FALLING,
-            description="Continuously falling barometric pressure trend",
-        )
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0]),
+                expected_value=BarometricPressureTrend.UNKNOWN,
+                description="Unknown trend",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([1]),
+                expected_value=BarometricPressureTrend.CONTINUOUSLY_FALLING,
+                description="Continuously falling barometric pressure trend",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([2]),
+                expected_value=BarometricPressureTrend.CONTINUOUSLY_RISING,
+                description="Continuously rising trend",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([9]),
+                expected_value=BarometricPressureTrend.STEADY,
+                description="Steady pressure",
+            ),
+        ]
 
     def test_barometric_pressure_trend_parsing(self, characteristic: BarometricPressureTrendCharacteristic) -> None:
         """Test Barometric Pressure Trend characteristic parsing."""
@@ -58,3 +75,22 @@ class TestBarometricPressureTrendCharacteristic(CommonCharacteristicTests):
         reserved_data = bytearray([UINT8_MAX])
         parsed = characteristic.decode_value(reserved_data)
         assert parsed == BarometricPressureTrend.UNKNOWN  # Falls back to UNKNOWN
+
+    @pytest.mark.parametrize(
+        "value,expected_trend",
+        [
+            (3, BarometricPressureTrend.FALLING_THEN_STEADY),
+            (4, BarometricPressureTrend.RISING_THEN_STEADY),
+            (5, BarometricPressureTrend.FALLING_BEFORE_LESSER_RISE),
+            (6, BarometricPressureTrend.FALLING_BEFORE_GREATER_RISE),
+            (7, BarometricPressureTrend.RISING_BEFORE_GREATER_FALL),
+            (8, BarometricPressureTrend.RISING_BEFORE_LESSER_FALL),
+        ],
+    )
+    def test_barometric_pressure_trend_all_valid_values(
+        self, characteristic: BarometricPressureTrendCharacteristic, value: int, expected_trend: BarometricPressureTrend
+    ) -> None:
+        """Test all valid barometric pressure trend values."""
+        data = bytearray([value])
+        result = characteristic.decode_value(data)
+        assert result == expected_trend

--- a/tests/gatt/characteristics/test_battery_level.py
+++ b/tests/gatt/characteristics/test_battery_level.py
@@ -26,11 +26,21 @@ class TestBatteryLevelCharacteristic(CommonCharacteristicTests):
         return "2A19"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
-        """Return valid test data for battery level (75%)."""
-        return CharacteristicTestData(input_data=bytearray([75]), expected_value=75, description="75% battery level")
+    def valid_test_data(self) -> list[CharacteristicTestData]:
+        """Return valid test data for battery level."""
+        return [
+            CharacteristicTestData(input_data=bytearray([0]), expected_value=0, description="0% battery level (empty)"),
+            CharacteristicTestData(
+                input_data=bytearray([50]), expected_value=50, description="50% battery level (half)"
+            ),
+            CharacteristicTestData(input_data=bytearray([75]), expected_value=75, description="75% battery level"),
+            CharacteristicTestData(
+                input_data=bytearray([100]), expected_value=100, description="100% battery level (full)"
+            ),
+        ]
 
     # === Battery-Specific Tests ===
+
     @pytest.mark.parametrize(
         "battery_level",
         [

--- a/tests/gatt/characteristics/test_characteristic_common.py
+++ b/tests/gatt/characteristics/test_characteristic_common.py
@@ -58,7 +58,7 @@ class CommonCharacteristicTests:
         )
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Default: fail with clear error if not overridden in subclass."""
         raise NotImplementedError(
             f"Test incomplete: missing 'valid_test_data' fixture in {type(self).__name__}. "
@@ -71,13 +71,13 @@ class CommonCharacteristicTests:
         assert characteristic.uuid == expected_uuid
 
     def test_parse_valid_data_succeeds(
-        self, characteristic: BaseCharacteristic, valid_test_data: CharacteristicTestData | list[CharacteristicTestData]
+        self, characteristic: BaseCharacteristic, valid_test_data: list[CharacteristicTestData]
     ) -> None:
         """Test parsing valid data succeeds and returns meaningful result."""
         # Handle both single and multiple test cases
-        test_cases = valid_test_data if isinstance(valid_test_data, list) else [valid_test_data]
-
-        for i, test_case in enumerate(test_cases):
+        if len(valid_test_data) < 2:
+            raise ValueError("valid_test_data should be a list with at least two test cases for this test to work")
+        for i, test_case in enumerate(valid_test_data):
             input_data = test_case.input_data
 
             result = characteristic.parse_value(input_data)

--- a/tests/gatt/characteristics/test_co2_concentration.py
+++ b/tests/gatt/characteristics/test_co2_concentration.py
@@ -20,11 +20,16 @@ class TestCO2ConcentrationCharacteristic(CommonCharacteristicTests):
         return "2B8C"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid CO2 concentration test data."""
-        return CharacteristicTestData(
-            input_data=bytearray([0x34, 0x12]), expected_value=4660, description="4660 ppm CO2 concentration"
-        )
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x34, 0x12]), expected_value=4660, description="4660 ppm CO2 concentration"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x90, 0x01]), expected_value=400, description="400 ppm typical outdoor CO2"
+            ),
+        ]
 
     def test_co2_concentration_boundary_values(self, characteristic: CO2ConcentrationCharacteristic) -> None:
         """Test CO2 concentration boundary values and validation."""

--- a/tests/gatt/characteristics/test_csc_feature.py
+++ b/tests/gatt/characteristics/test_csc_feature.py
@@ -19,16 +19,29 @@ class TestCSCFeatureCharacteristic(CommonCharacteristicTests):
         return "2A5C"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData | list[CharacteristicTestData]:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         # Example: Wheel and Crank Revolution Data Supported (0x03)
-        bitmask = CSCFeatures.WHEEL_REVOLUTION_DATA_SUPPORTED | CSCFeatures.CRANK_REVOLUTION_DATA_SUPPORTED
-        return CharacteristicTestData(
-            input_data=bytearray(bitmask.to_bytes(2, "little")),
-            expected_value=CSCFeatureData(
-                features=bitmask,
-                wheel_revolution_data_supported=True,
-                crank_revolution_data_supported=True,
-                multiple_sensor_locations_supported=False,
+        bitmask1 = CSCFeatures.WHEEL_REVOLUTION_DATA_SUPPORTED | CSCFeatures.CRANK_REVOLUTION_DATA_SUPPORTED
+        bitmask2 = CSCFeatures.WHEEL_REVOLUTION_DATA_SUPPORTED | CSCFeatures.MULTIPLE_SENSOR_LOCATIONS_SUPPORTED
+        return [
+            CharacteristicTestData(
+                input_data=bytearray(bitmask1.to_bytes(2, "little")),
+                expected_value=CSCFeatureData(
+                    features=bitmask1,
+                    wheel_revolution_data_supported=True,
+                    crank_revolution_data_supported=True,
+                    multiple_sensor_locations_supported=False,
+                ),
+                description="Wheel and Crank Revolution Data Supported (0x03)",
             ),
-            description="Wheel and Crank Revolution Data Supported (0x03)",
-        )
+            CharacteristicTestData(
+                input_data=bytearray(bitmask2.to_bytes(2, "little")),
+                expected_value=CSCFeatureData(
+                    features=bitmask2,
+                    wheel_revolution_data_supported=True,
+                    crank_revolution_data_supported=False,
+                    multiple_sensor_locations_supported=True,
+                ),
+                description="Wheel Revolution and Multiple Locations Supported",
+            ),
+        ]

--- a/tests/gatt/characteristics/test_csc_measurement.py
+++ b/tests/gatt/characteristics/test_csc_measurement.py
@@ -23,35 +23,56 @@ class TestCSCMeasurementCharacteristic(CommonCharacteristicTests):
         return "2A5B"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData | list[CharacteristicTestData]:
-        # Example: Both wheel and crank data present
-        # Flags: 0x03 (both present)
-        # Cumulative Wheel Revolutions: 123456 (0x0001E240)
-        # Last Wheel Event Time: 10240 (10.0s, 0x2800)
-        # Cumulative Crank Revolutions: 321 (0x0141)
-        # Last Crank Event Time: 2048 (2.0s, 0x0800)
-        flags = CSCMeasurementFlags.WHEEL_REVOLUTION_DATA_PRESENT | CSCMeasurementFlags.CRANK_REVOLUTION_DATA_PRESENT
-        wheel_revs = 123456
-        wheel_time = 10240  # 10.0s in 1/1024s units
-        crank_revs = 321
-        crank_time = 2048  # 2.0s in 1/1024s units
-        data = bytearray(
+    def valid_test_data(self) -> list[CharacteristicTestData]:
+        # Example 1: Both wheel and crank data present
+        flags1 = CSCMeasurementFlags.WHEEL_REVOLUTION_DATA_PRESENT | CSCMeasurementFlags.CRANK_REVOLUTION_DATA_PRESENT
+        wheel_revs1 = 123456
+        wheel_time1 = 10240  # 10.0s in 1/1024s units
+        crank_revs1 = 321
+        crank_time1 = 2048  # 2.0s in 1/1024s units
+        data1 = bytearray(
             [
-                int(flags),
-                *wheel_revs.to_bytes(4, "little"),
-                *wheel_time.to_bytes(2, "little"),
-                *crank_revs.to_bytes(2, "little"),
-                *crank_time.to_bytes(2, "little"),
+                int(flags1),
+                *wheel_revs1.to_bytes(4, "little"),
+                *wheel_time1.to_bytes(2, "little"),
+                *crank_revs1.to_bytes(2, "little"),
+                *crank_time1.to_bytes(2, "little"),
             ]
         )
-        return CharacteristicTestData(
-            input_data=data,
-            expected_value=CSCMeasurementData(
-                flags=flags,
-                cumulative_wheel_revolutions=wheel_revs,
-                last_wheel_event_time=wheel_time / 1024.0,
-                cumulative_crank_revolutions=crank_revs,
-                last_crank_event_time=crank_time / 1024.0,
-            ),
-            description="Both wheel and crank data present",
+
+        # Example 2: Only wheel data present
+        flags2 = CSCMeasurementFlags.WHEEL_REVOLUTION_DATA_PRESENT
+        wheel_revs2 = 50000
+        wheel_time2 = 5120  # 5.0s in 1/1024s units
+        data2 = bytearray(
+            [
+                int(flags2),
+                *wheel_revs2.to_bytes(4, "little"),
+                *wheel_time2.to_bytes(2, "little"),
+            ]
         )
+
+        return [
+            CharacteristicTestData(
+                input_data=data1,
+                expected_value=CSCMeasurementData(
+                    flags=flags1,
+                    cumulative_wheel_revolutions=wheel_revs1,
+                    last_wheel_event_time=wheel_time1 / 1024.0,
+                    cumulative_crank_revolutions=crank_revs1,
+                    last_crank_event_time=crank_time1 / 1024.0,
+                ),
+                description="Both wheel and crank data present",
+            ),
+            CharacteristicTestData(
+                input_data=data2,
+                expected_value=CSCMeasurementData(
+                    flags=flags2,
+                    cumulative_wheel_revolutions=wheel_revs2,
+                    last_wheel_event_time=wheel_time2 / 1024.0,
+                    cumulative_crank_revolutions=None,
+                    last_crank_event_time=None,
+                ),
+                description="Only wheel data present",
+            ),
+        ]

--- a/tests/gatt/characteristics/test_current_time.py
+++ b/tests/gatt/characteristics/test_current_time.py
@@ -1,0 +1,229 @@
+"""Tests for Current Time characteristic (0x2A2B)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from bluetooth_sig.gatt.characteristics.current_time import (
+    CurrentTimeCharacteristic,
+    CurrentTimeData,
+)
+from bluetooth_sig.types.gatt_enums import AdjustReason, DayOfWeek
+from tests.gatt.characteristics.test_characteristic_common import CharacteristicTestData, CommonCharacteristicTests
+
+
+class TestCurrentTimeCharacteristic(CommonCharacteristicTests):
+    """Test suite for Current Time characteristic.
+
+    Inherits behavioral tests from CommonCharacteristicTests.
+    Adds current time-specific validation and edge cases.
+    """
+
+    @pytest.fixture
+    def characteristic(self) -> CurrentTimeCharacteristic:
+        """Return a Current Time characteristic instance."""
+        return CurrentTimeCharacteristic()
+
+    @pytest.fixture
+    def expected_uuid(self) -> str:
+        """Return the expected UUID for Current Time characteristic."""
+        return "2A2B"
+
+    @pytest.fixture
+    def valid_test_data(self) -> list[CharacteristicTestData]:
+        """Return valid test data for current time (2025-01-15 14:30:45.128 Wednesday)."""
+        # 2025-01-15 14:30:45.128 Wednesday, manual time update
+        data = bytearray(
+            [
+                0xE9,
+                0x07,  # Year: 2025 (little-endian)
+                0x01,  # Month: January
+                0x0F,  # Day: 15
+                0x0E,  # Hours: 14
+                0x1E,  # Minutes: 30
+                0x2D,  # Seconds: 45
+                0x03,  # Day of Week: Wednesday
+                0x21,  # Fractions256: 33 (~0.128 seconds)
+                0x01,  # Adjust Reason: Manual time update
+            ]
+        )
+        expected = CurrentTimeData(
+            date_time=datetime(2025, 1, 15, 14, 30, 45),
+            day_of_week=DayOfWeek.WEDNESDAY,
+            fractions256=33,
+            adjust_reason=AdjustReason.MANUAL_TIME_UPDATE,
+        )
+
+        # Midnight on Monday with no adjustments
+        data_midnight = bytearray([0xE9, 0x07, 0x01, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00])
+        expected_midnight = CurrentTimeData(
+            date_time=datetime(2025, 1, 1, 0, 0, 0),
+            day_of_week=DayOfWeek.MONDAY,
+            fractions256=0,
+            adjust_reason=0,
+        )
+
+        # End of day with multiple adjust reasons (external ref + timezone change)
+        data_eod = bytearray([0xE9, 0x07, 0x0C, 0x1F, 0x17, 0x3B, 0x3B, 0x07, 0xFF, 0x06])
+        expected_eod = CurrentTimeData(
+            date_time=datetime(2025, 12, 31, 23, 59, 59),
+            day_of_week=DayOfWeek.SUNDAY,
+            fractions256=255,
+            adjust_reason=AdjustReason.EXTERNAL_REFERENCE_TIME_UPDATE | AdjustReason.CHANGE_OF_TIME_ZONE,
+        )
+
+        return [
+            CharacteristicTestData(
+                input_data=data, expected_value=expected, description="2025-01-15 14:30:45.128 Wednesday"
+            ),
+            CharacteristicTestData(
+                input_data=data_midnight, expected_value=expected_midnight, description="2025-01-01 00:00:00 Monday"
+            ),
+            CharacteristicTestData(
+                input_data=data_eod,
+                expected_value=expected_eod,
+                description="2025-12-31 23:59:59.996 Sunday with adjust reasons",
+            ),
+        ]
+
+    # === Current Time-Specific Tests ===
+    def test_current_time_with_unknown_fields(self, characteristic: CurrentTimeCharacteristic) -> None:
+        """Test current time with unknown year, month, and day."""
+        # Unknown date (0000-00-00) but valid time and day of week
+        data = bytearray(
+            [
+                0x00,
+                0x00,  # Year: 0 (unknown)
+                0x00,  # Month: 0 (unknown)
+                0x00,  # Day: 0 (unknown)
+                0x0C,  # Hours: 12
+                0x1E,  # Minutes: 30
+                0x00,  # Seconds: 0
+                0x01,  # Day of Week: Monday
+                0x00,  # Fractions256: 0
+                0x00,  # Adjust Reason: none
+            ]
+        )
+        result = characteristic.decode_value(data)
+        assert result.date_time is None  # Unknown date
+        assert result.day_of_week == DayOfWeek.MONDAY
+
+    def test_current_time_boundary_year(self, characteristic: CurrentTimeCharacteristic) -> None:
+        """Test current time with boundary year values."""
+        # Minimum valid year (1582)
+        data_min = bytearray([0x2E, 0x06, 0x01, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00])
+        result_min = characteristic.decode_value(data_min)
+        assert result_min.date_time is not None
+        assert result_min.date_time.year == 1582
+
+        # Maximum valid year (9999)
+        data_max = bytearray([0x0F, 0x27, 0x0C, 0x1F, 0x17, 0x3B, 0x3B, 0x07, 0xFF, 0x0F])
+        result_max = characteristic.decode_value(data_max)
+        assert result_max.date_time is not None
+        assert result_max.date_time.year == 9999
+
+    def test_current_time_invalid_year(self, characteristic: CurrentTimeCharacteristic) -> None:
+        """Test that invalid years are rejected."""
+        # Year too low (1) - datetime.MINYEAR is 1, but year 1 is technically valid
+        # We test year 10000 which exceeds datetime.MAXYEAR (9999)
+        data_high = bytearray([0x10, 0x27, 0x01, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00])
+        result = characteristic.parse_value(data_high)
+        assert not result.parse_success
+        assert "year" in result.error_message.lower() or "out of range" in result.error_message.lower()
+
+    def test_current_time_invalid_month(self, characteristic: CurrentTimeCharacteristic) -> None:
+        """Test that invalid months are rejected."""
+        data = bytearray([0xE9, 0x07, 0x0D, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00])  # Month: 13
+        result = characteristic.parse_value(data)
+        assert not result.parse_success
+        assert "month" in result.error_message.lower()
+
+    def test_current_time_invalid_day(self, characteristic: CurrentTimeCharacteristic) -> None:
+        """Test that invalid days are rejected."""
+        data = bytearray([0xE9, 0x07, 0x01, 0x20, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00])  # Day: 32
+        result = characteristic.parse_value(data)
+        assert not result.parse_success
+        assert "day" in result.error_message.lower()
+
+    def test_current_time_invalid_hours(self, characteristic: CurrentTimeCharacteristic) -> None:
+        """Test that invalid hours are rejected."""
+        data = bytearray([0xE9, 0x07, 0x01, 0x01, 0x18, 0x00, 0x00, 0x01, 0x00, 0x00])  # Hours: 24
+        result = characteristic.parse_value(data)
+        assert not result.parse_success
+        assert "hour" in result.error_message.lower()  # Python datetime says "hour"
+
+    def test_current_time_invalid_minutes(self, characteristic: CurrentTimeCharacteristic) -> None:
+        """Test that invalid minutes are rejected."""
+        data = bytearray([0xE9, 0x07, 0x01, 0x01, 0x00, 0x3C, 0x00, 0x01, 0x00, 0x00])  # Minutes: 60
+        result = characteristic.parse_value(data)
+        assert not result.parse_success
+        assert "minute" in result.error_message.lower()  # Python datetime says "minute"
+
+    def test_current_time_invalid_seconds(self, characteristic: CurrentTimeCharacteristic) -> None:
+        """Test that invalid seconds are rejected."""
+        data = bytearray([0xE9, 0x07, 0x01, 0x01, 0x00, 0x00, 0x3C, 0x01, 0x00, 0x00])  # Seconds: 60
+        result = characteristic.parse_value(data)
+        assert not result.parse_success
+        assert "second" in result.error_message.lower()  # Python datetime says "second"
+
+    def test_current_time_invalid_day_of_week(self, characteristic: CurrentTimeCharacteristic) -> None:
+        """Test that invalid day of week values are rejected."""
+        data = bytearray([0xE9, 0x07, 0x01, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00])  # Day of Week: 8
+        result = characteristic.parse_value(data)
+        assert not result.parse_success
+        assert "day of week" in result.error_message.lower()
+
+    @pytest.mark.parametrize(
+        "day_of_week,expected_enum",
+        [
+            (0, DayOfWeek.UNKNOWN),
+            (1, DayOfWeek.MONDAY),
+            (2, DayOfWeek.TUESDAY),
+            (3, DayOfWeek.WEDNESDAY),
+            (4, DayOfWeek.THURSDAY),
+            (5, DayOfWeek.FRIDAY),
+            (6, DayOfWeek.SATURDAY),
+            (7, DayOfWeek.SUNDAY),
+        ],
+    )
+    def test_current_time_day_of_week_values(
+        self, characteristic: CurrentTimeCharacteristic, day_of_week: int, expected_enum: DayOfWeek
+    ) -> None:
+        """Test all valid day of week values."""
+        data = bytearray([0xE9, 0x07, 0x01, 0x01, 0x00, 0x00, 0x00, day_of_week, 0x00, 0x00])
+        result = characteristic.decode_value(data)
+        assert result.day_of_week == expected_enum
+
+    def test_current_time_adjust_reason_flags(self, characteristic: CurrentTimeCharacteristic) -> None:
+        """Test adjust reason bitfield values."""
+        # Manual time update
+        data_manual = bytearray([0xE9, 0x07, 0x01, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01])
+        result = characteristic.decode_value(data_manual)
+        assert result.adjust_reason & AdjustReason.MANUAL_TIME_UPDATE
+
+        # Multiple reasons
+        data_multi = bytearray([0xE9, 0x07, 0x01, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x0F])
+        result = characteristic.decode_value(data_multi)
+        assert result.adjust_reason & AdjustReason.MANUAL_TIME_UPDATE
+        assert result.adjust_reason & AdjustReason.EXTERNAL_REFERENCE_TIME_UPDATE
+        assert result.adjust_reason & AdjustReason.CHANGE_OF_TIME_ZONE
+        assert result.adjust_reason & AdjustReason.CHANGE_OF_DST
+
+    def test_current_time_roundtrip(self, characteristic: CurrentTimeCharacteristic) -> None:
+        """Test that encode/decode are inverse operations."""
+        original = CurrentTimeData(
+            date_time=datetime(2025, 11, 1, 14, 30, 45),
+            day_of_week=DayOfWeek.SATURDAY,
+            fractions256=128,
+            adjust_reason=AdjustReason.EXTERNAL_REFERENCE_TIME_UPDATE,
+        )
+
+        encoded = characteristic.encode_value(original)
+        decoded = characteristic.decode_value(encoded)
+
+        assert decoded.date_time == original.date_time
+        assert decoded.day_of_week == original.day_of_week
+        assert decoded.fractions256 == original.fractions256
+        assert decoded.adjust_reason == original.adjust_reason

--- a/tests/gatt/characteristics/test_cycling_power_feature.py
+++ b/tests/gatt/characteristics/test_cycling_power_feature.py
@@ -23,24 +23,37 @@ class TestCyclingPowerFeatureCharacteristic(CommonCharacteristicTests):
         return "2A65"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid cycling power feature test data."""
-        return CharacteristicTestData(
-            input_data=bytearray(struct.pack("<I", 0x0000000F)),
-            expected_value=CyclingPowerFeatureData(
-                features=(
-                    CyclingPowerFeatures.PEDAL_POWER_BALANCE_SUPPORTED
-                    | CyclingPowerFeatures.ACCUMULATED_ENERGY_SUPPORTED
-                    | CyclingPowerFeatures.WHEEL_REVOLUTION_DATA_SUPPORTED
-                    | CyclingPowerFeatures.CRANK_REVOLUTION_DATA_SUPPORTED
+        return [
+            CharacteristicTestData(
+                input_data=bytearray(struct.pack("<I", 0x0000000F)),
+                expected_value=CyclingPowerFeatureData(
+                    features=(
+                        CyclingPowerFeatures.PEDAL_POWER_BALANCE_SUPPORTED
+                        | CyclingPowerFeatures.ACCUMULATED_ENERGY_SUPPORTED
+                        | CyclingPowerFeatures.WHEEL_REVOLUTION_DATA_SUPPORTED
+                        | CyclingPowerFeatures.CRANK_REVOLUTION_DATA_SUPPORTED
+                    ),
+                    pedal_power_balance_supported=True,
+                    accumulated_energy_supported=True,
+                    wheel_revolution_data_supported=True,
+                    crank_revolution_data_supported=True,
                 ),
-                pedal_power_balance_supported=True,
-                accumulated_energy_supported=True,
-                wheel_revolution_data_supported=True,
-                crank_revolution_data_supported=True,
+                description="Multiple features enabled",
             ),
-            description="Multiple features enabled",
-        )
+            CharacteristicTestData(
+                input_data=bytearray(struct.pack("<I", 0x00000001)),
+                expected_value=CyclingPowerFeatureData(
+                    features=CyclingPowerFeatures.PEDAL_POWER_BALANCE_SUPPORTED,
+                    pedal_power_balance_supported=True,
+                    accumulated_energy_supported=False,
+                    wheel_revolution_data_supported=False,
+                    crank_revolution_data_supported=False,
+                ),
+                description="Only pedal power balance supported",
+            ),
+        ]
 
     def test_cycling_power_feature_values(self, characteristic: CyclingPowerFeatureCharacteristic) -> None:
         """Test parsing cycling power feature values."""

--- a/tests/gatt/characteristics/test_dew_point.py
+++ b/tests/gatt/characteristics/test_dew_point.py
@@ -24,9 +24,21 @@ class TestDewPointCharacteristic(CommonCharacteristicTests):
         return "2A7B"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid dew point test data."""
-        return CharacteristicTestData(input_data=bytearray([25]), expected_value=25.0, description="25°C dew point")
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([256 - 20]),  # -20°C
+                expected_value=-20.0,
+                description="-20°C (cold climate)",
+            ),
+            CharacteristicTestData(input_data=bytearray([0]), expected_value=0.0, description="0°C (freezing point)"),
+            CharacteristicTestData(input_data=bytearray([10]), expected_value=10.0, description="10°C (cool)"),
+            CharacteristicTestData(input_data=bytearray([25]), expected_value=25.0, description="25°C (comfortable)"),
+            CharacteristicTestData(
+                input_data=bytearray([SINT8_MAX]), expected_value=127.0, description="127°C (maximum)"
+            ),
+        ]
 
     def test_dew_point_parsing(self, characteristic: DewPointCharacteristic) -> None:
         """Test dew point characteristic parsing."""
@@ -48,3 +60,31 @@ class TestDewPointCharacteristic(CommonCharacteristicTests):
         # Represent the signed -128 value as its unsigned 8-bit byte (0x80)
         data = bytearray([SINT8_MIN & 0xFF])  # Max negative sint8 (SINT8_MIN)
         assert characteristic.decode_value(data) == SINT8_MIN
+
+    def test_dew_point_boundary_values(self, characteristic: DewPointCharacteristic) -> None:
+        """Test dew point boundary values."""
+        # Minimum value (-128°C)
+        data_min = bytearray([SINT8_MIN & 0xFF])
+        assert characteristic.decode_value(data_min) == -128.0
+
+        # Maximum value (127°C)
+        data_max = bytearray([SINT8_MAX])
+        assert characteristic.decode_value(data_max) == 127.0
+
+        # Freezing point (0°C)
+        data_zero = bytearray([0])
+        assert characteristic.decode_value(data_zero) == 0.0
+
+    def test_dew_point_typical_values(self, characteristic: DewPointCharacteristic) -> None:
+        """Test typical dew point values."""
+        # Cold climate (-20°C)
+        data_cold = bytearray([256 - 20])  # Negative as unsigned byte
+        assert characteristic.decode_value(data_cold) == -20.0
+
+        # Cool (10°C)
+        data_cool = bytearray([10])
+        assert characteristic.decode_value(data_cool) == 10.0
+
+        # Comfortable (25°C)
+        data_comfortable = bytearray([25])
+        assert characteristic.decode_value(data_comfortable) == 25.0

--- a/tests/gatt/characteristics/test_glucose_feature.py
+++ b/tests/gatt/characteristics/test_glucose_feature.py
@@ -24,46 +24,64 @@ class TestGlucoseFeatureCharacteristic(CommonCharacteristicTests):
         return "2A51"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid test data for glucose feature characteristic."""
-        # Feature bitmap: 0x0403 = Low Battery + Sensor Malfunction + Multiple Bond
-        test_data = bytearray([0x03, 0x04])  # Little endian 0x0403
-
-        # Expected parsed data structure
-        expected_value = GlucoseFeatureData(
-            features_bitmap=(
-                GlucoseFeatures.LOW_BATTERY_DETECTION
-                | GlucoseFeatures.SENSOR_MALFUNCTION_DETECTION
-                | GlucoseFeatures.MULTIPLE_BOND_SUPPORT
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x03, 0x04]),  # 0x0403: Low Battery + Sensor Malfunction + Multiple Bond
+                expected_value=GlucoseFeatureData(
+                    features_bitmap=(
+                        GlucoseFeatures.LOW_BATTERY_DETECTION
+                        | GlucoseFeatures.SENSOR_MALFUNCTION_DETECTION
+                        | GlucoseFeatures.MULTIPLE_BOND_SUPPORT
+                    ),
+                    low_battery_detection=True,
+                    sensor_malfunction_detection=True,
+                    sensor_sample_size=False,
+                    sensor_strip_insertion_error=False,
+                    sensor_strip_type_error=False,
+                    sensor_result_high_low=False,
+                    sensor_temperature_high_low=False,
+                    sensor_read_interrupt=False,
+                    general_device_fault=False,
+                    time_fault=False,
+                    multiple_bond_support=True,
+                    enabled_features=(
+                        GlucoseFeatures.LOW_BATTERY_DETECTION,
+                        GlucoseFeatures.SENSOR_MALFUNCTION_DETECTION,
+                        GlucoseFeatures.MULTIPLE_BOND_SUPPORT,
+                    ),
+                    feature_count=3,
+                ),
+                description="Multiple glucose features enabled",
             ),
-            low_battery_detection=True,
-            sensor_malfunction_detection=True,
-            sensor_sample_size=False,
-            sensor_strip_insertion_error=False,
-            sensor_strip_type_error=False,
-            sensor_result_high_low=False,
-            sensor_temperature_high_low=False,
-            sensor_read_interrupt=False,
-            general_device_fault=False,
-            time_fault=False,
-            multiple_bond_support=True,
-            enabled_features=(
-                GlucoseFeatures.LOW_BATTERY_DETECTION,
-                GlucoseFeatures.SENSOR_MALFUNCTION_DETECTION,
-                GlucoseFeatures.MULTIPLE_BOND_SUPPORT,
+            CharacteristicTestData(
+                input_data=bytearray([0x01, 0x00]),  # 0x0001: Only Low Battery Detection
+                expected_value=GlucoseFeatureData(
+                    features_bitmap=GlucoseFeatures.LOW_BATTERY_DETECTION,
+                    low_battery_detection=True,
+                    sensor_malfunction_detection=False,
+                    sensor_sample_size=False,
+                    sensor_strip_insertion_error=False,
+                    sensor_strip_type_error=False,
+                    sensor_result_high_low=False,
+                    sensor_temperature_high_low=False,
+                    sensor_read_interrupt=False,
+                    general_device_fault=False,
+                    time_fault=False,
+                    multiple_bond_support=False,
+                    enabled_features=(GlucoseFeatures.LOW_BATTERY_DETECTION,),
+                    feature_count=1,
+                ),
+                description="Only low battery detection enabled",
             ),
-            feature_count=3,
-        )
-
-        return CharacteristicTestData(
-            input_data=test_data, expected_value=expected_value, description="Multiple glucose features enabled"
-        )
+        ]
 
     def test_glucose_feature_basic_parsing(
-        self, characteristic: GlucoseFeatureCharacteristic, valid_test_data: CharacteristicTestData
+        self, characteristic: GlucoseFeatureCharacteristic, valid_test_data: list[CharacteristicTestData]
     ) -> None:
         """Test basic glucose feature data parsing."""
-        test_data = valid_test_data.input_data
+        test_data = valid_test_data[0].input_data
 
         result = characteristic.decode_value(test_data)
         assert result.features_bitmap == GlucoseFeatures(0x0403)

--- a/tests/gatt/characteristics/test_heat_index.py
+++ b/tests/gatt/characteristics/test_heat_index.py
@@ -24,9 +24,21 @@ class TestHeatIndexCharacteristic(CommonCharacteristicTests):
         return "2A7A"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid heat index test data."""
-        return CharacteristicTestData(input_data=bytearray([35]), expected_value=35.0, description="35°C heat index")
+        return [
+            CharacteristicTestData(input_data=bytearray([27]), expected_value=27.0, description="27°C (caution level)"),
+            CharacteristicTestData(
+                input_data=bytearray([32]), expected_value=32.0, description="32°C (extreme caution)"
+            ),
+            CharacteristicTestData(input_data=bytearray([35]), expected_value=35.0, description="35°C (danger level)"),
+            CharacteristicTestData(
+                input_data=bytearray([41]), expected_value=41.0, description="41°C (extreme danger)"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([UINT8_MAX]), expected_value=255.0, description="255°C (maximum)"
+            ),
+        ]
 
     def test_heat_index_parsing(self, characteristic: HeatIndexCharacteristic) -> None:
         """Test heat index characteristic parsing."""
@@ -37,3 +49,31 @@ class TestHeatIndexCharacteristic(CommonCharacteristicTests):
         # Test max uint8
         data = bytearray([UINT8_MAX])  # UINT8_MAX°C
         assert characteristic.decode_value(data) == UINT8_MAX
+
+    def test_heat_index_boundary_values(self, characteristic: HeatIndexCharacteristic) -> None:
+        """Test heat index boundary values."""
+        # Minimum (0°C)
+        data_min = bytearray([0])
+        assert characteristic.decode_value(data_min) == 0.0
+
+        # Maximum (255°C)
+        data_max = bytearray([UINT8_MAX])
+        assert characteristic.decode_value(data_max) == 255.0
+
+    def test_heat_index_danger_levels(self, characteristic: HeatIndexCharacteristic) -> None:
+        """Test heat index danger levels based on typical thresholds."""
+        # Caution (27°C)
+        data_caution = bytearray([27])
+        assert characteristic.decode_value(data_caution) == 27.0
+
+        # Extreme caution (32°C)
+        data_extreme_caution = bytearray([32])
+        assert characteristic.decode_value(data_extreme_caution) == 32.0
+
+        # Danger (41°C)
+        data_danger = bytearray([41])
+        assert characteristic.decode_value(data_danger) == 41.0
+
+        # Extreme danger (54°C)
+        data_extreme_danger = bytearray([54])
+        assert characteristic.decode_value(data_extreme_danger) == 54.0

--- a/tests/gatt/characteristics/test_humidity.py
+++ b/tests/gatt/characteristics/test_humidity.py
@@ -23,11 +23,16 @@ class TestHumidityCharacteristic(CommonCharacteristicTests):
         return "2A6F"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
-        """Valid humidity test data (50.00%)."""
-        return CharacteristicTestData(
-            input_data=bytearray([0x88, 0x13]), expected_value=50.0, description="50.00% humidity"
-        )
+    def valid_test_data(self) -> list[CharacteristicTestData]:
+        """Valid humidity test data."""
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x88, 0x13]), expected_value=50.0, description="50.00% humidity"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x58, 0x1B]), expected_value=70.0, description="70.00% humidity"
+            ),
+        ]
 
     # === Humidity-Specific Tests ===
     def test_humidity_precision_and_range(self, characteristic: HumidityCharacteristic) -> None:

--- a/tests/gatt/characteristics/test_ln_control_point.py
+++ b/tests/gatt/characteristics/test_ln_control_point.py
@@ -33,35 +33,44 @@ class TestLNControlPointCharacteristic(CommonCharacteristicTests):
         return "2A6B"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Return valid test data for LN control point (set cumulative value request)."""
-        # LN Control Point request: op_code(1) + parameter(4)
-        data = bytearray(
-            [
-                0x01,  # op_code (SET_CUMULATIVE_VALUE)
-                0x00,
-                0x00,
-                0x00,
-                0x00,  # parameter (0)
-            ]
-        )
-        return CharacteristicTestData(
-            input_data=data,
-            expected_value=LNControlPointData(
-                op_code=LNControlPointOpCode.SET_CUMULATIVE_VALUE,
-                cumulative_value=0,
-                content_mask=None,
-                navigation_control_value=None,
-                route_number=None,
-                route_name=None,
-                fix_rate=None,
-                elevation=None,
-                request_op_code=None,
-                response_value=None,
-                response_parameter=None,
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x01, 0xE8, 0x03, 0x00, 0x00]),  # SET_CUMULATIVE_VALUE, value=1000
+                expected_value=LNControlPointData(
+                    op_code=LNControlPointOpCode.SET_CUMULATIVE_VALUE,
+                    cumulative_value=1000,
+                    content_mask=None,
+                    navigation_control_value=None,
+                    route_number=None,
+                    route_name=None,
+                    fix_rate=None,
+                    elevation=None,
+                    request_op_code=None,
+                    response_value=None,
+                    response_parameter=None,
+                ),
+                description="LN Control Point set cumulative value to 1000",
             ),
-            description="LN Control Point set cumulative value request",
-        )
+            CharacteristicTestData(
+                input_data=bytearray([0x03, 0x01]),  # NAVIGATION_CONTROL, start navigation
+                expected_value=LNControlPointData(
+                    op_code=LNControlPointOpCode.NAVIGATION_CONTROL,
+                    cumulative_value=None,
+                    content_mask=None,
+                    navigation_control_value=1,
+                    route_number=None,
+                    route_name=None,
+                    fix_rate=None,
+                    elevation=None,
+                    request_op_code=None,
+                    response_value=None,
+                    response_parameter=None,
+                ),
+                description="LN Control Point start navigation",
+            ),
+        ]
 
     # === LN Control Point-Specific Tests ===
     @pytest.mark.parametrize(

--- a/tests/gatt/characteristics/test_ln_feature.py
+++ b/tests/gatt/characteristics/test_ln_feature.py
@@ -27,38 +27,70 @@ class TestLNFeatureCharacteristic(CommonCharacteristicTests):
         return "2A6A"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Return valid test data for LN feature (basic features enabled)."""
-        # Features bitmap with some basic features enabled
-        features_bitmap = 0x0000001F  # Instantaneous speed, total distance, location, elevation, heading
-        return CharacteristicTestData(
-            input_data=bytearray(features_bitmap.to_bytes(4, byteorder="little")),
-            expected_value=LNFeatureData(
-                features_bitmap=features_bitmap,
-                instantaneous_speed_supported=True,
-                total_distance_supported=True,
-                location_supported=True,
-                elevation_supported=True,
-                heading_supported=True,
-                rolling_time_supported=False,
-                utc_time_supported=False,
-                remaining_distance_supported=False,
-                remaining_vertical_distance_supported=False,
-                estimated_time_of_arrival_supported=False,
-                number_of_beacons_in_solution_supported=False,
-                number_of_beacons_in_view_supported=False,
-                time_to_first_fix_supported=False,
-                estimated_horizontal_position_error_supported=False,
-                estimated_vertical_position_error_supported=False,
-                horizontal_dilution_of_precision_supported=False,
-                vertical_dilution_of_precision_supported=False,
-                location_and_speed_characteristic_content_masking_supported=False,
-                fix_rate_setting_supported=False,
-                elevation_setting_supported=False,
-                position_status_supported=False,
+        # Test 1: Basic features
+        features_bitmap1 = 0x0000001F  # Instantaneous speed, total distance, location, elevation, heading
+        # Test 2: Advanced features
+        features_bitmap2 = 0x00000FE0  # Rolling time, UTC time, remaining distance, etc.
+        return [
+            CharacteristicTestData(
+                input_data=bytearray(features_bitmap1.to_bytes(4, byteorder="little")),
+                expected_value=LNFeatureData(
+                    features_bitmap=features_bitmap1,
+                    instantaneous_speed_supported=True,
+                    total_distance_supported=True,
+                    location_supported=True,
+                    elevation_supported=True,
+                    heading_supported=True,
+                    rolling_time_supported=False,
+                    utc_time_supported=False,
+                    remaining_distance_supported=False,
+                    remaining_vertical_distance_supported=False,
+                    estimated_time_of_arrival_supported=False,
+                    number_of_beacons_in_solution_supported=False,
+                    number_of_beacons_in_view_supported=False,
+                    time_to_first_fix_supported=False,
+                    estimated_horizontal_position_error_supported=False,
+                    estimated_vertical_position_error_supported=False,
+                    horizontal_dilution_of_precision_supported=False,
+                    vertical_dilution_of_precision_supported=False,
+                    location_and_speed_characteristic_content_masking_supported=False,
+                    fix_rate_setting_supported=False,
+                    elevation_setting_supported=False,
+                    position_status_supported=False,
+                ),
+                description="LN Feature with basic features enabled",
             ),
-            description="LN Feature with basic features enabled",
-        )
+            CharacteristicTestData(
+                input_data=bytearray(features_bitmap2.to_bytes(4, byteorder="little")),
+                expected_value=LNFeatureData(
+                    features_bitmap=features_bitmap2,
+                    instantaneous_speed_supported=False,
+                    total_distance_supported=False,
+                    location_supported=False,
+                    elevation_supported=False,
+                    heading_supported=False,
+                    rolling_time_supported=True,
+                    utc_time_supported=True,
+                    remaining_distance_supported=True,
+                    remaining_vertical_distance_supported=True,
+                    estimated_time_of_arrival_supported=True,
+                    number_of_beacons_in_solution_supported=True,
+                    number_of_beacons_in_view_supported=True,
+                    time_to_first_fix_supported=False,
+                    estimated_horizontal_position_error_supported=False,
+                    estimated_vertical_position_error_supported=False,
+                    horizontal_dilution_of_precision_supported=False,
+                    vertical_dilution_of_precision_supported=False,
+                    location_and_speed_characteristic_content_masking_supported=False,
+                    fix_rate_setting_supported=False,
+                    elevation_setting_supported=False,
+                    position_status_supported=False,
+                ),
+                description="LN Feature with advanced features enabled",
+            ),
+        ]
 
     # === LN Feature-Specific Tests ===
     @pytest.mark.parametrize(

--- a/tests/gatt/characteristics/test_local_time_information.py
+++ b/tests/gatt/characteristics/test_local_time_information.py
@@ -28,17 +28,28 @@ class TestLocalTimeInformationCharacteristic(CommonCharacteristicTests):
         return "2A0F"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Returns valid test data for LocalTimeInformationCharacteristic."""
-        return CharacteristicTestData(
-            input_data=bytearray([8, 4]),  # timezone=+2h (8*15min), dst=+1h (value 4)
-            expected_value=LocalTimeInformationData(
-                timezone=TimezoneInfo(description="UTC+02:00", offset_hours=2.0, raw_value=8),
-                dst_offset=DSTOffsetInfo(description="Daylight Time", offset_hours=1.0, raw_value=4),
-                total_offset_hours=3.0,
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([4, 4]),  # timezone=+1h (4*15min), dst=+1h (value 4)
+                expected_value=LocalTimeInformationData(
+                    timezone=TimezoneInfo(description="UTC+01:00", offset_hours=1.0, raw_value=4),
+                    dst_offset=DSTOffsetInfo(description="Daylight Time", offset_hours=1.0, raw_value=4),
+                    total_offset_hours=2.0,
+                ),
+                description="UTC+1 with DST (+1 hour) = total offset 2 hours",
             ),
-            description="UTC+2 with DST (+1 hour) = total offset 3 hours",
-        )
+            CharacteristicTestData(
+                input_data=bytearray([0xFC, 0]),  # timezone=-1h (-4*15min), dst=standard time (value 0)
+                expected_value=LocalTimeInformationData(
+                    timezone=TimezoneInfo(description="UTC-01:00", offset_hours=-1.0, raw_value=-4),
+                    dst_offset=DSTOffsetInfo(description="Standard Time", offset_hours=0.0, raw_value=0),
+                    total_offset_hours=-1.0,
+                ),
+                description="UTC-1 with standard time (no DST) = total offset -1 hour",
+            ),
+        ]
 
     def test_local_time_information_parsing(self, characteristic: LocalTimeInformationCharacteristic) -> None:
         """Test Local Time Information characteristic parsing."""

--- a/tests/gatt/characteristics/test_location_and_speed.py
+++ b/tests/gatt/characteristics/test_location_and_speed.py
@@ -36,29 +36,49 @@ class TestLocationAndSpeedCharacteristic(CommonCharacteristicTests):
         return "2A67"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
-        """Return valid test data for location and speed (minimal data)."""
-        # Minimal location and speed data: flags(2) + instantaneous_speed(2)
-        data = bytearray([0x01, 0x00, 0xE8, 0x03])  # flags=0x0001 (speed present), speed=0x03E8=1000 (10.00 m/s)
-        return CharacteristicTestData(
-            input_data=data,
-            expected_value=LocationAndSpeedData(
-                flags=LocationAndSpeedFlags.INSTANTANEOUS_SPEED_PRESENT,
-                instantaneous_speed=10.0,
-                total_distance=None,
-                latitude=None,
-                longitude=None,
-                elevation=None,
-                heading=None,
-                rolling_time=None,
-                utc_time=None,
-                position_status=PositionStatus.NO_POSITION,
-                speed_and_distance_format=SpeedAndDistanceFormat.FORMAT_2D,
-                elevation_source=ElevationSource.POSITIONING_SYSTEM,
-                heading_source=HeadingSource.HEADING_BASED_ON_MOVEMENT,
+    def valid_test_data(self) -> list[CharacteristicTestData]:
+        """Return valid test data for location and speed."""
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x01, 0x00, 0xE8, 0x03]),  # flags=0x0001 (speed present), speed=1000 (10.00 m/s)
+                expected_value=LocationAndSpeedData(
+                    flags=LocationAndSpeedFlags.INSTANTANEOUS_SPEED_PRESENT,
+                    instantaneous_speed=10.0,
+                    total_distance=None,
+                    latitude=None,
+                    longitude=None,
+                    elevation=None,
+                    heading=None,
+                    rolling_time=None,
+                    utc_time=None,
+                    position_status=PositionStatus.NO_POSITION,
+                    speed_and_distance_format=SpeedAndDistanceFormat.FORMAT_2D,
+                    elevation_source=ElevationSource.POSITIONING_SYSTEM,
+                    heading_source=HeadingSource.HEADING_BASED_ON_MOVEMENT,
+                ),
+                description="Location and Speed with instantaneous speed only",
             ),
-            description="Location and Speed with instantaneous speed only",
-        )
+            CharacteristicTestData(
+                input_data=bytearray([0x03, 0x00, 0x90, 0x01, 0x10, 0x27, 0x00]),  # speed + distance
+                expected_value=LocationAndSpeedData(
+                    flags=LocationAndSpeedFlags.INSTANTANEOUS_SPEED_PRESENT
+                    | LocationAndSpeedFlags.TOTAL_DISTANCE_PRESENT,
+                    instantaneous_speed=4.0,  # 400 * 0.01 = 4.0 m/s
+                    total_distance=1000.0,  # 10000 * 0.1 = 1000.0 m
+                    latitude=None,
+                    longitude=None,
+                    elevation=None,
+                    heading=None,
+                    rolling_time=None,
+                    utc_time=None,
+                    position_status=PositionStatus.NO_POSITION,
+                    speed_and_distance_format=SpeedAndDistanceFormat.FORMAT_2D,
+                    elevation_source=ElevationSource.POSITIONING_SYSTEM,
+                    heading_source=HeadingSource.HEADING_BASED_ON_MOVEMENT,
+                ),
+                description="Location and Speed with speed and distance",
+            ),
+        ]
 
     # === Location and Speed-Specific Tests ===
     @pytest.mark.parametrize(

--- a/tests/gatt/characteristics/test_magnetic_declination.py
+++ b/tests/gatt/characteristics/test_magnetic_declination.py
@@ -23,11 +23,35 @@ class TestMagneticDeclinationCharacteristic(CommonCharacteristicTests):
         return "2A2C"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid magnetic declination test data."""
-        return CharacteristicTestData(
-            input_data=bytearray([0x40, 0x46]), expected_value=179.84, description="179.84 degrees magnetic declination"
-        )
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x00, 0x00]),
+                expected_value=0.0,
+                description="0.0° (no declination)",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x28, 0x23]),
+                expected_value=90.0,
+                description="90.0° (east)",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x40, 0x46]),
+                expected_value=179.84,
+                description="179.84° (near south)",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x78, 0x69]),
+                expected_value=270.0,
+                description="270.0° (west)",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x9F, 0x8C]),
+                expected_value=359.99,
+                description="359.99° (maximum)",
+            ),
+        ]
 
     def test_magnetic_declination_parsing(self, characteristic: MagneticDeclinationCharacteristic) -> None:
         """Test Magnetic Declination characteristic parsing."""
@@ -52,3 +76,17 @@ class TestMagneticDeclinationCharacteristic(CommonCharacteristicTests):
         # Test insufficient data
         with pytest.raises(ValueError, match="Insufficient data"):
             characteristic.decode_value(bytearray([0x12]))
+
+    def test_magnetic_declination_cardinal_directions(self, characteristic: MagneticDeclinationCharacteristic) -> None:
+        """Test magnetic declination cardinal directions."""
+        # North (0°)
+        data_north = bytearray([0x00, 0x00])
+        assert characteristic.decode_value(data_north) == 0.0
+
+        # East (90°)
+        data_east = bytearray([0x28, 0x23])  # 9000 * 0.01 = 90.0
+        assert characteristic.decode_value(data_east) == 90.0
+
+        # West (270°)
+        data_west = bytearray([0x78, 0x69])  # 27000 * 0.01 = 270.0
+        assert characteristic.decode_value(data_west) == 270.0

--- a/tests/gatt/characteristics/test_magnetic_flux_density_3d.py
+++ b/tests/gatt/characteristics/test_magnetic_flux_density_3d.py
@@ -26,13 +26,20 @@ class TestMagneticFluxDensity3DCharacteristic(CommonCharacteristicTests):
         return "2AA1"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid magnetic flux density 3D test data."""
-        return CharacteristicTestData(
-            input_data=bytearray(struct.pack("<hhh", 1000, -500, 2000)),
-            expected_value=VectorData(x_axis=1e-4, y_axis=-5e-5, z_axis=2e-4),
-            description="Magnetic flux density 3D X=1000, Y=-500, Z=2000",
-        )
+        return [
+            CharacteristicTestData(
+                input_data=bytearray(struct.pack("<hhh", 1000, -500, 2000)),
+                expected_value=VectorData(x_axis=1e-4, y_axis=-5e-5, z_axis=2e-4),
+                description="Magnetic flux density 3D X=1000, Y=-500, Z=2000",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray(struct.pack("<hhh", 500, 750, -1000)),
+                expected_value=VectorData(x_axis=5e-5, y_axis=7.5e-5, z_axis=-1e-4),
+                description="Magnetic flux density 3D X=500, Y=750, Z=-1000",
+            ),
+        ]
 
     def test_magnetic_flux_density_3d_parsing(self, characteristic: MagneticFluxDensity3DCharacteristic) -> None:
         """Test Magnetic Flux Density 3D characteristic parsing."""

--- a/tests/gatt/characteristics/test_methane_concentration.py
+++ b/tests/gatt/characteristics/test_methane_concentration.py
@@ -20,11 +20,16 @@ class TestMethaneConcentrationCharacteristic(CommonCharacteristicTests):
         return "2BD1"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid methane concentration test data."""
-        return CharacteristicTestData(
-            input_data=bytearray([0x64, 0x00]), expected_value=100, description="100 ppm methane concentration"
-        )
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x02, 0x00]), expected_value=2, description="2 ppm (typical atmosphere)"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x32, 0x00]), expected_value=50, description="50 ppm (elevated)"
+            ),
+        ]
 
     def test_methane_concentration_parsing(self, characteristic: MethaneConcentrationCharacteristic) -> None:
         """Test methane concentration characteristic parsing."""
@@ -35,3 +40,23 @@ class TestMethaneConcentrationCharacteristic(CommonCharacteristicTests):
         test_data = bytearray([0x64, 0x00])  # 100 ppm little endian
         parsed = characteristic.decode_value(test_data)
         assert parsed == 100
+
+    def test_methane_concentration_boundary_values(self, characteristic: MethaneConcentrationCharacteristic) -> None:
+        """Test boundary methane concentration values."""
+        # No methane
+        data_min = bytearray([0x00, 0x00])
+        assert characteristic.decode_value(data_min) == 0
+
+        # Maximum
+        data_max = bytearray([0xFF, 0xFF])
+        assert characteristic.decode_value(data_max) == 65535
+
+    def test_methane_concentration_typical_levels(self, characteristic: MethaneConcentrationCharacteristic) -> None:
+        """Test typical methane concentration levels."""
+        # Atmospheric level (2 ppm)
+        data_atm = bytearray([0x02, 0x00])
+        assert characteristic.decode_value(data_atm) == 2
+
+        # Elevated (50 ppm)
+        data_elevated = bytearray([0x32, 0x00])
+        assert characteristic.decode_value(data_elevated) == 50

--- a/tests/gatt/characteristics/test_navigation.py
+++ b/tests/gatt/characteristics/test_navigation.py
@@ -35,36 +35,44 @@ class TestNavigationCharacteristic(CommonCharacteristicTests):
         return "2A68"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Return valid test data for navigation (bearing and heading)."""
-        # Navigation data: flags(2) + bearing(2) + heading(2)
-        data = bytearray(
-            [
-                0x00,
-                0x00,  # flags (no optional fields)
-                0x5A,
-                0x00,  # bearing (90.0 degrees)
-                0x2D,
-                0x01,  # heading (301.0 degrees)
-            ]
-        )
-        return CharacteristicTestData(
-            input_data=data,
-            expected_value=NavigationData(
-                flags=NavigationFlags(0),
-                bearing=0.9,  # 0x005A = 90 units of 0.01 degrees = 0.9 degrees
-                heading=3.01,  # 0x012D = 301 units of 0.01 degrees = 3.01 degrees
-                remaining_distance=None,
-                remaining_vertical_distance=None,
-                estimated_time_of_arrival=None,
-                position_status=PositionStatus.NO_POSITION,
-                heading_source=HeadingSource.HEADING_BASED_ON_MOVEMENT,
-                navigation_indicator_type=NavigationIndicatorType.TO_WAYPOINT,
-                waypoint_reached=False,
-                destination_reached=False,
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x00, 0x00, 0x5A, 0x00, 0x2D, 0x01]),  # bearing=90, heading=301
+                expected_value=NavigationData(
+                    flags=NavigationFlags(0),
+                    bearing=0.9,  # 90 units of 0.01 degrees = 0.9 degrees
+                    heading=3.01,  # 301 units of 0.01 degrees = 3.01 degrees
+                    remaining_distance=None,
+                    remaining_vertical_distance=None,
+                    estimated_time_of_arrival=None,
+                    position_status=PositionStatus.NO_POSITION,
+                    heading_source=HeadingSource.HEADING_BASED_ON_MOVEMENT,
+                    navigation_indicator_type=NavigationIndicatorType.TO_WAYPOINT,
+                    waypoint_reached=False,
+                    destination_reached=False,
+                ),
+                description="Navigation with bearing and heading",
             ),
-            description="Navigation with bearing and heading",
-        )
+            CharacteristicTestData(
+                input_data=bytearray([0x00, 0x00, 0xB4, 0x00, 0x68, 0x01]),  # bearing=180, heading=360
+                expected_value=NavigationData(
+                    flags=NavigationFlags(0),
+                    bearing=1.8,  # 180 units of 0.01 degrees = 1.8 degrees
+                    heading=3.6,  # 360 units of 0.01 degrees = 3.6 degrees
+                    remaining_distance=None,
+                    remaining_vertical_distance=None,
+                    estimated_time_of_arrival=None,
+                    position_status=PositionStatus.NO_POSITION,
+                    heading_source=HeadingSource.HEADING_BASED_ON_MOVEMENT,
+                    navigation_indicator_type=NavigationIndicatorType.TO_WAYPOINT,
+                    waypoint_reached=False,
+                    destination_reached=False,
+                ),
+                description="Navigation with bearing 180 and heading 360",
+            ),
+        ]
 
     # === Navigation-Specific Tests ===
     @pytest.mark.parametrize(

--- a/tests/gatt/characteristics/test_new_alert.py
+++ b/tests/gatt/characteristics/test_new_alert.py
@@ -1,0 +1,86 @@
+"""Tests for New Alert characteristic (0x2A46)."""
+
+from __future__ import annotations
+
+import pytest
+
+from bluetooth_sig.gatt.characteristics.new_alert import NewAlertCharacteristic, NewAlertData
+from bluetooth_sig.types import AlertCategoryID
+from tests.gatt.characteristics.test_characteristic_common import CharacteristicTestData, CommonCharacteristicTests
+
+
+class TestNewAlertCharacteristic(CommonCharacteristicTests):
+    """Test suite for New Alert characteristic."""
+
+    @pytest.fixture
+    def characteristic(self) -> NewAlertCharacteristic:
+        """Return a New Alert characteristic instance."""
+        return NewAlertCharacteristic()
+
+    @pytest.fixture
+    def expected_uuid(self) -> str:
+        """Return the expected UUID."""
+        return "2A46"
+
+    @pytest.fixture
+    def valid_test_data(self) -> list[CharacteristicTestData]:
+        """Return valid test data."""
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x01, 0x03]) + b"John",
+                expected_value=NewAlertData(
+                    category_id=AlertCategoryID.EMAIL, number_of_new_alert=3, text_string_information="John"
+                ),
+                description="3 new emails from John",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x03, 0x02]) + b"Alice",
+                expected_value=NewAlertData(
+                    category_id=AlertCategoryID.CALL, number_of_new_alert=2, text_string_information="Alice"
+                ),
+                description="2 new calls from Alice",
+            ),
+        ]
+
+    def test_new_alert_without_text(self, characteristic: NewAlertCharacteristic) -> None:
+        """Test new alert with no text information."""
+        data = bytearray([0x00, 0x01])  # Simple Alert, 1 new alert, no text
+        result = characteristic.decode_value(data)
+        assert result.category_id == AlertCategoryID.SIMPLE_ALERT
+        assert result.number_of_new_alert == 1
+        assert result.text_string_information == ""
+
+    def test_new_alert_with_max_text(self, characteristic: NewAlertCharacteristic) -> None:
+        """Test new alert with maximum 18-character text."""
+        text = "A" * 18
+        data = bytearray([0x03, 0x02]) + text.encode("utf-8")  # Call, 2 alerts, 18 chars
+        result = characteristic.decode_value(data)
+        assert result.category_id == AlertCategoryID.CALL
+        assert result.number_of_new_alert == 2
+        assert result.text_string_information == text
+
+    def test_new_alert_text_too_long(self, characteristic: NewAlertCharacteristic) -> None:
+        """Test that text longer than 18 characters is rejected."""
+        text = "A" * 19
+        data = bytearray([0x01, 0x01]) + text.encode("utf-8")
+        result = characteristic.parse_value(data)
+        assert not result.parse_success
+        assert "text string too long" in result.error_message.lower()
+
+    def test_invalid_category_id(self, characteristic: NewAlertCharacteristic) -> None:
+        """Test that invalid category IDs are rejected."""
+        data = bytearray([0x0A, 0x01])  # 10 is reserved
+        result = characteristic.parse_value(data)
+        assert not result.parse_success
+        assert "category id" in result.error_message.lower()
+
+    def test_roundtrip(self, characteristic: NewAlertCharacteristic) -> None:
+        """Test encode/decode roundtrip."""
+        original = NewAlertData(
+            category_id=AlertCategoryID.SMS_MMS, number_of_new_alert=5, text_string_information="Alice"
+        )
+        encoded = characteristic.encode_value(original)
+        decoded = characteristic.decode_value(encoded)
+        assert decoded.category_id == original.category_id
+        assert decoded.number_of_new_alert == original.number_of_new_alert
+        assert decoded.text_string_information == original.text_string_information

--- a/tests/gatt/characteristics/test_nitrogen_dioxide_concentration.py
+++ b/tests/gatt/characteristics/test_nitrogen_dioxide_concentration.py
@@ -20,11 +20,20 @@ class TestNitrogenDioxideConcentrationCharacteristic(CommonCharacteristicTests):
         return "2BD2"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid nitrogen dioxide concentration test data."""
-        return CharacteristicTestData(
-            input_data=bytearray([0x32, 0x00]), expected_value=50, description="50 ppb nitrogen dioxide concentration"
-        )
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x28, 0x00]),
+                expected_value=40,
+                description="40 ppb (typical urban)",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0xC8, 0x00]),
+                expected_value=200,
+                description="200 ppb (high pollution)",
+            ),
+        ]
 
     def test_nitrogen_dioxide_concentration_parsing(
         self, characteristic: NitrogenDioxideConcentrationCharacteristic
@@ -37,3 +46,27 @@ class TestNitrogenDioxideConcentrationCharacteristic(CommonCharacteristicTests):
         test_data = bytearray([0x32, 0x00])  # 50 ppb little endian
         parsed = characteristic.decode_value(test_data)
         assert parsed == 50
+
+    def test_nitrogen_dioxide_concentration_boundary_values(
+        self, characteristic: NitrogenDioxideConcentrationCharacteristic
+    ) -> None:
+        """Test boundary NO2 concentration values."""
+        # Clean air
+        data_min = bytearray([0x00, 0x00])
+        assert characteristic.decode_value(data_min) == 0
+
+        # Maximum
+        data_max = bytearray([0xFF, 0xFF])
+        assert characteristic.decode_value(data_max) == 65535
+
+    def test_nitrogen_dioxide_concentration_typical_levels(
+        self, characteristic: NitrogenDioxideConcentrationCharacteristic
+    ) -> None:
+        """Test typical NO2 concentration levels."""
+        # Typical urban (40 ppb)
+        data_urban = bytearray([0x28, 0x00])
+        assert characteristic.decode_value(data_urban) == 40
+
+        # High pollution (200 ppb)
+        data_high = bytearray([0xC8, 0x00])
+        assert characteristic.decode_value(data_high) == 200

--- a/tests/gatt/characteristics/test_non_methane_voc_concentration.py
+++ b/tests/gatt/characteristics/test_non_methane_voc_concentration.py
@@ -22,13 +22,20 @@ class TestNonMethaneVOCConcentrationCharacteristic(CommonCharacteristicTests):
         return "2BD3"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid Non-Methane VOC concentration test data."""
-        return CharacteristicTestData(
-            input_data=bytearray([0x34, 0x92]),
-            expected_value=5640.0,
-            description="IEEE 11073 SFLOAT Non-Methane VOC concentration",
-        )
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x0A, 0x80]),  # 10 in IEEE 11073 SFLOAT
+                expected_value=10.0,
+                description="10 ppb Non-Methane VOC concentration",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x64, 0x80]),  # 100 in IEEE 11073 SFLOAT
+                expected_value=100.0,
+                description="100 ppb Non-Methane VOC concentration",
+            ),
+        ]
 
     def test_tvoc_concentration_parsing(self, characteristic: NonMethaneVOCConcentrationCharacteristic) -> None:
         """Test TVOC concentration characteristic parsing."""

--- a/tests/gatt/characteristics/test_ozone_concentration.py
+++ b/tests/gatt/characteristics/test_ozone_concentration.py
@@ -23,11 +23,16 @@ class TestOzoneConcentrationCharacteristic(CommonCharacteristicTests):
         return "2BD4"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid ozone concentration test data."""
-        return CharacteristicTestData(
-            input_data=bytearray([0x64, 0x00]), expected_value=100.0, description="100.0 ppb ozone concentration"
-        )
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x32, 0x00]), expected_value=50.0, description="50.0 ppb (typical low)"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x64, 0x00]), expected_value=100.0, description="100.0 ppb (typical moderate)"
+            ),
+        ]
 
     def test_ozone_concentration_parsing(self, characteristic: OzoneConcentrationCharacteristic) -> None:
         """Test ozone concentration characteristic parsing."""
@@ -38,3 +43,27 @@ class TestOzoneConcentrationCharacteristic(CommonCharacteristicTests):
         test_data = bytearray([0x64, 0x00])  # 100 ppb little endian
         parsed = characteristic.decode_value(test_data)
         assert parsed == 100
+
+    def test_ozone_concentration_boundary_values(self, characteristic: OzoneConcentrationCharacteristic) -> None:
+        """Test ozone concentration boundary values."""
+        # Minimum value
+        data_min = bytearray([0x00, 0x00])
+        assert characteristic.decode_value(data_min) == 0.0
+
+        # Maximum value (uint16 max)
+        data_max = bytearray([0xFF, 0xFF])
+        assert characteristic.decode_value(data_max) == 65535.0
+
+    def test_ozone_concentration_typical_values(self, characteristic: OzoneConcentrationCharacteristic) -> None:
+        """Test typical ozone concentration values."""
+        # Low concentration (50 ppb)
+        data_low = bytearray([0x32, 0x00])
+        assert characteristic.decode_value(data_low) == 50.0
+
+        # Moderate concentration (100 ppb)
+        data_moderate = bytearray([0x64, 0x00])
+        assert characteristic.decode_value(data_moderate) == 100.0
+
+        # High concentration (500 ppb)
+        data_high = bytearray([0xF4, 0x01])
+        assert characteristic.decode_value(data_high) == 500.0

--- a/tests/gatt/characteristics/test_pm10_concentration.py
+++ b/tests/gatt/characteristics/test_pm10_concentration.py
@@ -23,11 +23,16 @@ class TestPM10ConcentrationCharacteristic(CommonCharacteristicTests):
         return "2BD7"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid PM10 concentration test data."""
-        return CharacteristicTestData(
-            input_data=bytearray([0x32, 0x00]), expected_value=50.0, description="50.0 µg/m³ PM10 concentration"
-        )
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x32, 0x00]), expected_value=50.0, description="50.0 µg/m³ PM10 concentration"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x64, 0x00]), expected_value=100.0, description="100.0 µg/m³ PM10 concentration"
+            ),
+        ]
 
     def test_pm10_concentration_parsing(self, characteristic: PM10ConcentrationCharacteristic) -> None:
         """Test PM10 concentration characteristic parsing."""

--- a/tests/gatt/characteristics/test_pm1_concentration.py
+++ b/tests/gatt/characteristics/test_pm1_concentration.py
@@ -23,11 +23,16 @@ class TestPM1ConcentrationCharacteristic(CommonCharacteristicTests):
         return "2BD5"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid PM1 concentration test data."""
-        return CharacteristicTestData(
-            input_data=bytearray([0x32, 0x00]), expected_value=50.0, description="50.0 µg/m³ PM1 concentration"
-        )
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x0A, 0x00]), expected_value=10.0, description="10.0 µg/m³ (good)"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x32, 0x00]), expected_value=50.0, description="50.0 µg/m³ (moderate)"
+            ),
+        ]
 
     def test_pm1_concentration_parsing(self, characteristic: PM1ConcentrationCharacteristic) -> None:
         """Test PM1 concentration characteristic parsing."""
@@ -38,3 +43,27 @@ class TestPM1ConcentrationCharacteristic(CommonCharacteristicTests):
         test_data = bytearray([0x32, 0x00])  # 50 µg/m³ little endian
         parsed = characteristic.decode_value(test_data)
         assert parsed == 50
+
+    def test_pm1_concentration_boundary_values(self, characteristic: PM1ConcentrationCharacteristic) -> None:
+        """Test PM1 concentration boundary values."""
+        # Clean air
+        data_min = bytearray([0x00, 0x00])
+        assert characteristic.decode_value(data_min) == 0.0
+
+        # Maximum
+        data_max = bytearray([0xFF, 0xFF])
+        assert characteristic.decode_value(data_max) == 65535.0
+
+    def test_pm1_concentration_air_quality_levels(self, characteristic: PM1ConcentrationCharacteristic) -> None:
+        """Test PM1 concentration air quality levels."""
+        # Good (10 µg/m³)
+        data_good = bytearray([0x0A, 0x00])
+        assert characteristic.decode_value(data_good) == 10.0
+
+        # Moderate (50 µg/m³)
+        data_moderate = bytearray([0x32, 0x00])
+        assert characteristic.decode_value(data_moderate) == 50.0
+
+        # Unhealthy (150 µg/m³)
+        data_unhealthy = bytearray([0x96, 0x00])
+        assert characteristic.decode_value(data_unhealthy) == 150.0

--- a/tests/gatt/characteristics/test_pm25_concentration.py
+++ b/tests/gatt/characteristics/test_pm25_concentration.py
@@ -20,11 +20,16 @@ class TestPM25ConcentrationCharacteristic(CommonCharacteristicTests):
         return "2BD6"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid PM2.5 concentration test data."""
-        return CharacteristicTestData(
-            input_data=bytearray([0x19, 0x00]), expected_value=25, description="25 µg/m³ PM2.5 concentration"
-        )
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x19, 0x00]), expected_value=25, description="25 µg/m³ PM2.5 concentration"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x32, 0x00]), expected_value=50, description="50 µg/m³ PM2.5 concentration"
+            ),
+        ]
 
     def test_pm25_concentration_parsing(self, characteristic: PM25ConcentrationCharacteristic) -> None:
         """Test PM2.5 concentration characteristic parsing."""

--- a/tests/gatt/characteristics/test_position_quality.py
+++ b/tests/gatt/characteristics/test_position_quality.py
@@ -33,34 +33,40 @@ class TestPositionQualityCharacteristic(CommonCharacteristicTests):
         return "2A69"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Return valid test data for position quality (basic quality metrics)."""
-        # Position quality data: flags(2) + time_to_first_fix(2) + hdop(1) + vdop(1)
-        data = bytearray(
-            [
-                0x64,
-                0x00,  # flags (time_to_first_fix, hdop, vdop present)
-                0x10,
-                0x27,  # time_to_first_fix (1000 seconds)
-                0x04,  # hdop (2.0)
-                0x06,  # vdop (3.0)
-            ]
-        )
-        return CharacteristicTestData(
-            input_data=data,
-            expected_value=PositionQualityData(
-                flags=PositionQualityFlags(0x0064),
-                number_of_beacons_in_solution=None,
-                number_of_beacons_in_view=None,
-                time_to_first_fix=1000.0,  # 10000 / 10
-                ehpe=None,
-                evpe=None,
-                hdop=2.0,
-                vdop=3.0,
-                position_status=PositionStatus.NO_POSITION,
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x64, 0x00, 0x10, 0x27, 0x04, 0x06]),  # ttff, hdop, vdop
+                expected_value=PositionQualityData(
+                    flags=PositionQualityFlags(0x0064),
+                    number_of_beacons_in_solution=None,
+                    number_of_beacons_in_view=None,
+                    time_to_first_fix=1000.0,
+                    ehpe=None,
+                    evpe=None,
+                    hdop=2.0,
+                    vdop=3.0,
+                    position_status=PositionStatus.NO_POSITION,
+                ),
+                description="Position Quality with HDOP, VDOP, and time to first fix",
             ),
-            description="Position Quality with HDOP, VDOP, and time to first fix",
-        )
+            CharacteristicTestData(
+                input_data=bytearray([0x03, 0x00, 0x05, 0x0A]),  # beacon counts
+                expected_value=PositionQualityData(
+                    flags=PositionQualityFlags(0x0003),
+                    number_of_beacons_in_solution=5,
+                    number_of_beacons_in_view=10,
+                    time_to_first_fix=None,
+                    ehpe=None,
+                    evpe=None,
+                    hdop=None,
+                    vdop=None,
+                    position_status=PositionStatus.NO_POSITION,
+                ),
+                description="Position Quality with beacon counts",
+            ),
+        ]
 
     # === Position Quality-Specific Tests ===
     @pytest.mark.parametrize(

--- a/tests/gatt/characteristics/test_rainfall.py
+++ b/tests/gatt/characteristics/test_rainfall.py
@@ -23,11 +23,25 @@ class TestRainfallCharacteristic(CommonCharacteristicTests):
         return "2A78"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid rainfall test data."""
-        return CharacteristicTestData(
-            input_data=bytearray([0xE2, 0x04]), expected_value=1250.0, description="1250.0 mm rainfall"
-        )
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x00, 0x00]), expected_value=0.0, description="0.0 mm (no rain)"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x0A, 0x00]), expected_value=10.0, description="10.0 mm (light rain)"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x64, 0x00]), expected_value=100.0, description="100.0 mm (moderate rain)"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0xE2, 0x04]), expected_value=1250.0, description="1250.0 mm (heavy rain)"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0xFF, 0xFF]), expected_value=65535.0, description="65535.0 mm (maximum)"
+            ),
+        ]
 
     def test_rainfall_parsing(self, characteristic: RainfallCharacteristic) -> None:
         """Test Rainfall characteristic parsing."""
@@ -38,3 +52,23 @@ class TestRainfallCharacteristic(CommonCharacteristicTests):
         test_data = bytearray([0xE2, 0x04])  # 1250 in little endian uint16
         parsed = characteristic.decode_value(test_data)
         assert parsed == 1250.0
+
+    def test_rainfall_boundary_values(self, characteristic: RainfallCharacteristic) -> None:
+        """Test rainfall boundary values."""
+        # No rainfall
+        data_zero = bytearray([0x00, 0x00])
+        assert characteristic.decode_value(data_zero) == 0.0
+
+        # Maximum rainfall
+        data_max = bytearray([0xFF, 0xFF])
+        assert characteristic.decode_value(data_max) == 65535.0
+
+    def test_rainfall_typical_values(self, characteristic: RainfallCharacteristic) -> None:
+        """Test typical rainfall values."""
+        # Light rain (10 mm)
+        data_light = bytearray([0x0A, 0x00])
+        assert characteristic.decode_value(data_light) == 10.0
+
+        # Moderate rain (100 mm)
+        data_moderate = bytearray([0x64, 0x00])
+        assert characteristic.decode_value(data_moderate) == 100.0

--- a/tests/gatt/characteristics/test_reference_time_information.py
+++ b/tests/gatt/characteristics/test_reference_time_information.py
@@ -1,0 +1,199 @@
+"""Tests for Reference Time Information characteristic (0x2A14)."""
+
+from __future__ import annotations
+
+import pytest
+
+from bluetooth_sig.gatt.characteristics.reference_time_information import (
+    ReferenceTimeInformationCharacteristic,
+    ReferenceTimeInformationData,
+    TimeSource,
+)
+from tests.gatt.characteristics.test_characteristic_common import CharacteristicTestData, CommonCharacteristicTests
+
+
+class TestReferenceTimeInformationCharacteristic(CommonCharacteristicTests):
+    """Test suite for Reference Time Information characteristic.
+
+    Inherits behavioral tests from CommonCharacteristicTests.
+    Adds reference time information-specific validation and edge cases.
+    """
+
+    @pytest.fixture
+    def characteristic(self) -> ReferenceTimeInformationCharacteristic:
+        """Return a Reference Time Information characteristic instance."""
+        return ReferenceTimeInformationCharacteristic()
+
+    @pytest.fixture
+    def expected_uuid(self) -> str:
+        """Return the expected UUID for Reference Time Information characteristic."""
+        return "2A14"
+
+    @pytest.fixture
+    def valid_test_data(self) -> list[CharacteristicTestData]:
+        """Return valid test data for reference time information."""
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x01, 0x02, 0x05, 0x03]),  # NTP, 250ms accuracy, 5 days + 3 hours
+                expected_value=ReferenceTimeInformationData(
+                    time_source=TimeSource.NETWORK_TIME_PROTOCOL,
+                    time_accuracy=2,
+                    days_since_update=5,
+                    hours_since_update=3,
+                ),
+                description="NTP, 250ms accuracy, 5 days + 3 hours since update",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x02, 0x01, 0x01, 0x12]),  # GPS, 125ms accuracy, 1 day + 18 hours
+                expected_value=ReferenceTimeInformationData(
+                    time_source=TimeSource.GPS,
+                    time_accuracy=1,
+                    days_since_update=1,
+                    hours_since_update=18,
+                ),
+                description="GPS, 125ms accuracy, 1 day + 18 hours since update",
+            ),
+        ]
+
+    # === Reference Time Information-Specific Tests ===
+    @pytest.mark.parametrize(
+        "time_source,expected_enum",
+        [
+            (0, TimeSource.UNKNOWN),
+            (1, TimeSource.NETWORK_TIME_PROTOCOL),
+            (2, TimeSource.GPS),
+            (3, TimeSource.RADIO_TIME_SIGNAL),
+            (4, TimeSource.MANUAL),
+            (5, TimeSource.ATOMIC_CLOCK),
+            (6, TimeSource.CELLULAR_NETWORK),
+            (7, TimeSource.NOT_SYNCHRONIZED),
+        ],
+    )
+    def test_reference_time_information_time_source_values(
+        self, characteristic: ReferenceTimeInformationCharacteristic, time_source: int, expected_enum: TimeSource
+    ) -> None:
+        """Test all valid time source values."""
+        data = bytearray([time_source, 0x00, 0x00, 0x00])
+        result = characteristic.decode_value(data)
+        assert result.time_source == expected_enum
+
+    def test_reference_time_information_time_accuracy_boundary_values(
+        self, characteristic: ReferenceTimeInformationCharacteristic
+    ) -> None:
+        """Test time accuracy boundary values."""
+        # Minimum accuracy (0 = 0ms drift)
+        data_min = bytearray([0x01, 0x00, 0x00, 0x00])
+        result_min = characteristic.decode_value(data_min)
+        assert result_min.time_accuracy == 0
+
+        # Maximum valid accuracy (253 = 31.625s drift)
+        data_max_valid = bytearray([0x01, 0xFD, 0x00, 0x00])
+        result_max_valid = characteristic.decode_value(data_max_valid)
+        assert result_max_valid.time_accuracy == 253
+
+        # Out of range indicator (254 = >31.625s drift)
+        data_out_of_range = bytearray([0x01, 0xFE, 0x00, 0x00])
+        result_out_of_range = characteristic.decode_value(data_out_of_range)
+        assert result_out_of_range.time_accuracy == 254
+
+        # Unknown accuracy (255)
+        data_unknown = bytearray([0x01, 0xFF, 0x00, 0x00])
+        result_unknown = characteristic.decode_value(data_unknown)
+        assert result_unknown.time_accuracy == 255
+
+    def test_reference_time_information_days_since_update_boundary_values(
+        self, characteristic: ReferenceTimeInformationCharacteristic
+    ) -> None:
+        """Test days since update boundary values."""
+        # Minimum days (0)
+        data_min = bytearray([0x01, 0x00, 0x00, 0x00])
+        result_min = characteristic.decode_value(data_min)
+        assert result_min.days_since_update == 0
+
+        # Maximum valid days (254)
+        data_max = bytearray([0x01, 0x00, 0xFE, 0x00])
+        result_max = characteristic.decode_value(data_max)
+        assert result_max.days_since_update == 254
+
+        # Out of range indicator (255 = >=255 days)
+        data_out_of_range = bytearray([0x01, 0x00, 0xFF, 0x00])
+        result_out_of_range = characteristic.decode_value(data_out_of_range)
+        assert result_out_of_range.days_since_update == 255
+
+    def test_reference_time_information_hours_since_update_valid_values(
+        self, characteristic: ReferenceTimeInformationCharacteristic
+    ) -> None:
+        """Test hours since update valid values."""
+        # Minimum hours (0)
+        data_min = bytearray([0x01, 0x00, 0x00, 0x00])
+        result_min = characteristic.decode_value(data_min)
+        assert result_min.hours_since_update == 0
+
+        # Maximum valid hours (23)
+        data_max = bytearray([0x01, 0x00, 0x00, 0x17])
+        result_max = characteristic.decode_value(data_max)
+        assert result_max.hours_since_update == 23
+
+        # Out of range indicator (255 = >=255 days)
+        data_out_of_range = bytearray([0x01, 0x00, 0x00, 0xFF])
+        result_out_of_range = characteristic.decode_value(data_out_of_range)
+        assert result_out_of_range.hours_since_update == 255
+
+    def test_reference_time_information_invalid_hours_since_update(
+        self, characteristic: ReferenceTimeInformationCharacteristic
+    ) -> None:
+        """Test that invalid hours since update values are rejected."""
+        # Hours: 24 (invalid, should be 0-23 or 255)
+        data_invalid = bytearray([0x01, 0x00, 0x00, 0x18])
+        result = characteristic.parse_value(data_invalid)
+        assert not result.parse_success
+        assert "hours since update" in result.error_message.lower()
+
+    def test_reference_time_information_invalid_time_source(
+        self, characteristic: ReferenceTimeInformationCharacteristic
+    ) -> None:
+        """Test that invalid time source values are rejected."""
+        # Time source: 100 (reserved, should be 0-7)
+        data_invalid = bytearray([0x64, 0x00, 0x00, 0x00])
+        result = characteristic.parse_value(data_invalid)
+        assert not result.parse_success
+        assert "time source" in result.error_message.lower()
+
+    def test_reference_time_information_gps_zero_drift(
+        self, characteristic: ReferenceTimeInformationCharacteristic
+    ) -> None:
+        """Test GPS time source with zero drift and no update."""
+        data = bytearray([0x02, 0x00, 0x00, 0x00])  # GPS, 0ms accuracy, 0 days + 0 hours
+        result = characteristic.decode_value(data)
+        assert result.time_source == TimeSource.GPS
+        assert result.time_accuracy == 0
+        assert result.days_since_update == 0
+        assert result.hours_since_update == 0
+
+    def test_reference_time_information_not_synchronized_unknown_accuracy(
+        self, characteristic: ReferenceTimeInformationCharacteristic
+    ) -> None:
+        """Test not synchronized time source with unknown accuracy."""
+        data = bytearray([0x07, 0xFF, 0xFF, 0xFF])  # Not synchronized, unknown accuracy, >=255 days
+        result = characteristic.decode_value(data)
+        assert result.time_source == TimeSource.NOT_SYNCHRONIZED
+        assert result.time_accuracy == 255  # Unknown
+        assert result.days_since_update == 255  # >=255 days
+        assert result.hours_since_update == 255  # >=255 days
+
+    def test_reference_time_information_roundtrip(self, characteristic: ReferenceTimeInformationCharacteristic) -> None:
+        """Test that encode/decode are inverse operations."""
+        original = ReferenceTimeInformationData(
+            time_source=TimeSource.CELLULAR_NETWORK,
+            time_accuracy=50,  # 50 * 125ms = 6.25s
+            days_since_update=100,
+            hours_since_update=12,
+        )
+
+        encoded = characteristic.encode_value(original)
+        decoded = characteristic.decode_value(encoded)
+
+        assert decoded.time_source == original.time_source
+        assert decoded.time_accuracy == original.time_accuracy
+        assert decoded.days_since_update == original.days_since_update
+        assert decoded.hours_since_update == original.hours_since_update

--- a/tests/gatt/characteristics/test_supported_new_alert_category.py
+++ b/tests/gatt/characteristics/test_supported_new_alert_category.py
@@ -1,0 +1,76 @@
+"""Tests for Supported New Alert Category characteristic (0x2A47)."""
+
+from __future__ import annotations
+
+import pytest
+
+from bluetooth_sig.gatt.characteristics.supported_new_alert_category import SupportedNewAlertCategoryCharacteristic
+from bluetooth_sig.types import AlertCategoryBitMask
+from tests.gatt.characteristics.test_characteristic_common import CharacteristicTestData, CommonCharacteristicTests
+
+
+class TestSupportedNewAlertCategoryCharacteristic(CommonCharacteristicTests):
+    """Test suite for Supported New Alert Category characteristic."""
+
+    @pytest.fixture
+    def characteristic(self) -> SupportedNewAlertCategoryCharacteristic:
+        """Return a Supported New Alert Category characteristic instance."""
+        return SupportedNewAlertCategoryCharacteristic()
+
+    @pytest.fixture
+    def expected_uuid(self) -> str:
+        """Return the expected UUID."""
+        return "2A47"
+
+    @pytest.fixture
+    def valid_test_data(self) -> list[CharacteristicTestData]:
+        """Return valid test data (Email + SMS + Call categories enabled)."""
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x2A, 0x00]),  # Bits 1, 3, 5 set (Email, Call, SMS)
+                expected_value=AlertCategoryBitMask.EMAIL | AlertCategoryBitMask.CALL | AlertCategoryBitMask.SMS_MMS,
+                description="Email + Call + SMS categories",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x00, 0x00]),
+                expected_value=0,
+                description="No categories enabled",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0xFF, 0x03]),  # All 10 defined bits set
+                expected_value=(
+                    AlertCategoryBitMask.SIMPLE_ALERT
+                    | AlertCategoryBitMask.EMAIL
+                    | AlertCategoryBitMask.NEWS
+                    | AlertCategoryBitMask.CALL
+                    | AlertCategoryBitMask.MISSED_CALL
+                    | AlertCategoryBitMask.SMS_MMS
+                    | AlertCategoryBitMask.VOICE_MAIL
+                    | AlertCategoryBitMask.SCHEDULE
+                    | AlertCategoryBitMask.HIGH_PRIORITIZED_ALERT
+                    | AlertCategoryBitMask.INSTANT_MESSAGE
+                ),
+                description="All categories enabled",
+            ),
+        ]
+
+    def test_all_categories_enabled(self, characteristic: SupportedNewAlertCategoryCharacteristic) -> None:
+        """Test with all defined categories enabled."""
+        data = bytearray([0xFF, 0x03])  # All 10 defined bits set
+        result = characteristic.decode_value(data)
+        assert result & AlertCategoryBitMask.SIMPLE_ALERT
+        assert result & AlertCategoryBitMask.EMAIL
+        assert result & AlertCategoryBitMask.INSTANT_MESSAGE
+
+    def test_no_categories_enabled(self, characteristic: SupportedNewAlertCategoryCharacteristic) -> None:
+        """Test with no categories enabled."""
+        data = bytearray([0x00, 0x00])
+        result = characteristic.decode_value(data)
+        assert result == 0
+
+    def test_roundtrip(self, characteristic: SupportedNewAlertCategoryCharacteristic) -> None:
+        """Test encode/decode roundtrip."""
+        original = AlertCategoryBitMask.EMAIL | AlertCategoryBitMask.HIGH_PRIORITIZED_ALERT
+        encoded = characteristic.encode_value(original)
+        decoded = characteristic.decode_value(encoded)
+        assert decoded == original

--- a/tests/gatt/characteristics/test_supported_unread_alert_category.py
+++ b/tests/gatt/characteristics/test_supported_unread_alert_category.py
@@ -1,0 +1,61 @@
+"""Tests for Supported Unread Alert Category characteristic (0x2A48)."""
+
+from __future__ import annotations
+
+import pytest
+
+from bluetooth_sig.gatt.characteristics.supported_unread_alert_category import (
+    SupportedUnreadAlertCategoryCharacteristic,
+)
+from bluetooth_sig.types import AlertCategoryBitMask
+from tests.gatt.characteristics.test_characteristic_common import CharacteristicTestData, CommonCharacteristicTests
+
+
+class TestSupportedUnreadAlertCategoryCharacteristic(CommonCharacteristicTests):
+    """Test suite for Supported Unread Alert Category characteristic."""
+
+    @pytest.fixture
+    def characteristic(self) -> SupportedUnreadAlertCategoryCharacteristic:
+        """Return a Supported Unread Alert Category characteristic instance."""
+        return SupportedUnreadAlertCategoryCharacteristic()
+
+    @pytest.fixture
+    def expected_uuid(self) -> str:
+        """Return the expected UUID."""
+        return "2A48"
+
+    @pytest.fixture
+    def valid_test_data(self) -> list[CharacteristicTestData]:
+        """Return valid test data."""
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x02, 0x00]),  # Bit 1 set (Email)
+                expected_value=AlertCategoryBitMask.EMAIL,
+                description="Email category only",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x0A, 0x00]),  # Bits 1, 3 set (Email, Call)
+                expected_value=AlertCategoryBitMask.EMAIL | AlertCategoryBitMask.CALL,
+                description="Email + Call categories",
+            ),
+        ]
+
+    def test_single_category(self, characteristic: SupportedUnreadAlertCategoryCharacteristic) -> None:
+        """Test with single category enabled."""
+        data = bytearray([0x01, 0x00])  # Bit 0 set (Simple Alert)
+        result = characteristic.decode_value(data)
+        assert result == AlertCategoryBitMask.SIMPLE_ALERT
+
+    def test_all_categories(self, characteristic: SupportedUnreadAlertCategoryCharacteristic) -> None:
+        """Test with all categories enabled."""
+        data = bytearray([0xFF, 0x03])
+        result = characteristic.decode_value(data)
+        assert result & AlertCategoryBitMask.NEWS
+        assert result & AlertCategoryBitMask.SCHEDULE
+
+    def test_roundtrip(self, characteristic: SupportedUnreadAlertCategoryCharacteristic) -> None:
+        """Test encode/decode roundtrip."""
+        original = AlertCategoryBitMask.MISSED_CALL | AlertCategoryBitMask.SMS_MMS
+        encoded = characteristic.encode_value(original)
+        decoded = characteristic.decode_value(encoded)
+        assert decoded == original

--- a/tests/gatt/characteristics/test_time_zone.py
+++ b/tests/gatt/characteristics/test_time_zone.py
@@ -25,11 +25,18 @@ class TestTimeZoneCharacteristic(CommonCharacteristicTests):
         return "2A0E"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid time zone test data."""
-        return CharacteristicTestData(
-            input_data=bytearray(struct.pack("b", 4)), expected_value="UTC+01:00", description="UTC+01:00 time zone"
-        )
+        return [
+            CharacteristicTestData(
+                input_data=bytearray(struct.pack("b", 4)), expected_value="UTC+01:00", description="UTC+01:00 time zone"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray(struct.pack("b", -20)),
+                expected_value="UTC-05:00",
+                description="UTC-05:00 time zone",
+            ),
+        ]
 
     def test_time_zone_parsing(self, characteristic: TimeZoneCharacteristic) -> None:
         """Test Time Zone characteristic parsing."""

--- a/tests/gatt/characteristics/test_true_wind_direction.py
+++ b/tests/gatt/characteristics/test_true_wind_direction.py
@@ -23,11 +23,14 @@ class TestTrueWindDirectionCharacteristic(CommonCharacteristicTests):
         return "2A71"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid true wind direction test data."""
-        return CharacteristicTestData(
-            input_data=bytearray([0x50, 0x46]), expected_value=180.0, description="180° true wind direction"
-        )
+        return [
+            CharacteristicTestData(input_data=bytearray([0x28, 0x23]), expected_value=90.0, description="90° (East)"),
+            CharacteristicTestData(
+                input_data=bytearray([0x50, 0x46]), expected_value=180.0, description="180° (South)"
+            ),
+        ]
 
     def test_true_wind_direction_parsing(self, characteristic: TrueWindDirectionCharacteristic) -> None:
         """Test true wind direction characteristic parsing."""
@@ -38,3 +41,31 @@ class TestTrueWindDirectionCharacteristic(CommonCharacteristicTests):
         # Test 0° (north)
         data = bytearray([0x00, 0x00])
         assert characteristic.decode_value(data) == 0.0
+
+    def test_true_wind_direction_cardinal_directions(self, characteristic: TrueWindDirectionCharacteristic) -> None:
+        """Test cardinal wind directions."""
+        # North (0°)
+        data_north = bytearray([0x00, 0x00])
+        assert characteristic.decode_value(data_north) == 0.0
+
+        # East (90°)
+        data_east = bytearray([0x28, 0x23])  # 9000 * 0.01 = 90.0
+        assert characteristic.decode_value(data_east) == 90.0
+
+        # South (180°)
+        data_south = bytearray([0x50, 0x46])  # 18000 * 0.01 = 180.0
+        assert characteristic.decode_value(data_south) == 180.0
+
+        # West (270°)
+        data_west = bytearray([0x78, 0x69])  # 27000 * 0.01 = 270.0
+        assert characteristic.decode_value(data_west) == 270.0
+
+    def test_true_wind_direction_boundary_values(self, characteristic: TrueWindDirectionCharacteristic) -> None:
+        """Test boundary values for wind direction."""
+        # Minimum (0°)
+        data_min = bytearray([0x00, 0x00])
+        assert characteristic.decode_value(data_min) == 0.0
+
+        # Maximum (359.99°)
+        data_max = bytearray([0x9F, 0x8C])  # 35999 * 0.01 = 359.99
+        assert characteristic.decode_value(data_max) == 359.99

--- a/tests/gatt/characteristics/test_true_wind_speed.py
+++ b/tests/gatt/characteristics/test_true_wind_speed.py
@@ -23,11 +23,25 @@ class TestTrueWindSpeedCharacteristic(CommonCharacteristicTests):
         return "2A70"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid true wind speed test data."""
-        return CharacteristicTestData(
-            input_data=bytearray([0x1A, 0x04]), expected_value=10.50, description="10.50 m/s true wind speed"
-        )
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x00, 0x00]), expected_value=0.0, description="0.0 m/s (calm)"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0xF4, 0x01]), expected_value=5.0, description="5.0 m/s (light breeze)"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x1A, 0x04]), expected_value=10.50, description="10.50 m/s (fresh breeze)"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0xDC, 0x05]), expected_value=15.0, description="15.0 m/s (strong breeze)"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0xFF, 0xFF]), expected_value=655.35, description="655.35 m/s (maximum)"
+            ),
+        ]
 
     def test_true_wind_speed_parsing(self, characteristic: TrueWindSpeedCharacteristic) -> None:
         """Test true wind speed characteristic parsing."""
@@ -41,3 +55,27 @@ class TestTrueWindSpeedCharacteristic(CommonCharacteristicTests):
         # Test zero wind
         data = bytearray([0x00, 0x00])
         assert characteristic.decode_value(data) == 0.0
+
+    def test_true_wind_speed_boundary_values(self, characteristic: TrueWindSpeedCharacteristic) -> None:
+        """Test boundary wind speed values."""
+        # Minimum (calm)
+        data_min = bytearray([0x00, 0x00])
+        assert characteristic.decode_value(data_min) == 0.0
+
+        # Maximum
+        data_max = bytearray([0xFF, 0xFF])
+        assert characteristic.decode_value(data_max) == 655.35
+
+    def test_true_wind_speed_beaufort_scale_examples(self, characteristic: TrueWindSpeedCharacteristic) -> None:
+        """Test wind speeds corresponding to Beaufort scale."""
+        # Light breeze (5 m/s, Beaufort 3)
+        data_light = bytearray([0xF4, 0x01])  # 500 * 0.01 = 5.0
+        assert characteristic.decode_value(data_light) == 5.0
+
+        # Fresh breeze (10.5 m/s, Beaufort 5)
+        data_fresh = bytearray([0x1A, 0x04])  # 1050 * 0.01 = 10.50
+        assert characteristic.decode_value(data_fresh) == 10.50
+
+        # Strong breeze (15 m/s, Beaufort 6)
+        data_strong = bytearray([0xDC, 0x05])  # 1500 * 0.01 = 15.0
+        assert characteristic.decode_value(data_strong) == 15.0

--- a/tests/gatt/characteristics/test_unread_alert_status.py
+++ b/tests/gatt/characteristics/test_unread_alert_status.py
@@ -1,0 +1,71 @@
+"""Tests for Unread Alert Status characteristic (0x2A45)."""
+
+from __future__ import annotations
+
+import pytest
+
+from bluetooth_sig.gatt.characteristics.unread_alert_status import (
+    UnreadAlertStatusCharacteristic,
+    UnreadAlertStatusData,
+)
+from bluetooth_sig.types import AlertCategoryID
+from tests.gatt.characteristics.test_characteristic_common import CharacteristicTestData, CommonCharacteristicTests
+
+
+class TestUnreadAlertStatusCharacteristic(CommonCharacteristicTests):
+    """Test suite for Unread Alert Status characteristic."""
+
+    @pytest.fixture
+    def characteristic(self) -> UnreadAlertStatusCharacteristic:
+        """Return an Unread Alert Status characteristic instance."""
+        return UnreadAlertStatusCharacteristic()
+
+    @pytest.fixture
+    def expected_uuid(self) -> str:
+        """Return the expected UUID."""
+        return "2A45"
+
+    @pytest.fixture
+    def valid_test_data(self) -> list[CharacteristicTestData]:
+        """Return valid test data."""
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x01, 0x0A]),  # Email, 10 unread
+                expected_value=UnreadAlertStatusData(category_id=AlertCategoryID.EMAIL, unread_count=10),
+                description="10 unread emails",
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x04, 0x03]),  # Missed Call, 3 unread
+                expected_value=UnreadAlertStatusData(category_id=AlertCategoryID.MISSED_CALL, unread_count=3),
+                description="3 missed calls",
+            ),
+        ]
+
+    def test_zero_unread(self, characteristic: UnreadAlertStatusCharacteristic) -> None:
+        """Test with zero unread alerts."""
+        data = bytearray([0x05, 0x00])  # SMS/MMS, 0 unread
+        result = characteristic.decode_value(data)
+        assert result.category_id == AlertCategoryID.SMS_MMS
+        assert result.unread_count == 0
+
+    def test_max_unread_count(self, characteristic: UnreadAlertStatusCharacteristic) -> None:
+        """Test with 255 (more than 254 unread)."""
+        data = bytearray([0x04, 0xFF])  # Missed Call, 255 (>254)
+        result = characteristic.decode_value(data)
+        assert result.category_id == AlertCategoryID.MISSED_CALL
+        assert result.unread_count == 255
+
+    def test_invalid_category_id(self, characteristic: UnreadAlertStatusCharacteristic) -> None:
+        """Test that invalid category IDs are rejected."""
+        data = bytearray([0x0A, 0x05])  # 10 is reserved
+        result = characteristic.parse_value(data)
+        assert not result.parse_success
+        assert "category id" in result.error_message.lower()
+
+    def test_roundtrip(self, characteristic: UnreadAlertStatusCharacteristic) -> None:
+        """Test encode/decode roundtrip."""
+        original = UnreadAlertStatusData(category_id=AlertCategoryID.VOICE_MAIL, unread_count=3)
+        encoded = characteristic.encode_value(original)
+        decoded = characteristic.decode_value(encoded)
+        assert decoded.category_id == original.category_id
+        assert decoded.unread_count == original.unread_count

--- a/tests/gatt/characteristics/test_uv_index.py
+++ b/tests/gatt/characteristics/test_uv_index.py
@@ -19,6 +19,9 @@ class TestUVIndexCharacteristic(CommonCharacteristicTests):
         return "2A76"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData | list[CharacteristicTestData]:
-        # Example: UV Index = 7 (high)
-        return CharacteristicTestData(input_data=bytearray([7]), expected_value=7, description="UV Index = 7 (high)")
+    def valid_test_data(self) -> list[CharacteristicTestData]:
+        # Example: UV Index values
+        return [
+            CharacteristicTestData(input_data=bytearray([3]), expected_value=3, description="UV Index = 3 (moderate)"),
+            CharacteristicTestData(input_data=bytearray([7]), expected_value=7, description="UV Index = 7 (high)"),
+        ]

--- a/tests/gatt/characteristics/test_voc_concentration.py
+++ b/tests/gatt/characteristics/test_voc_concentration.py
@@ -20,11 +20,16 @@ class TestVOCConcentrationCharacteristic(CommonCharacteristicTests):
         return "2BE7"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid VOC concentration test data."""
-        return CharacteristicTestData(
-            input_data=bytearray([0x00, 0x04]), expected_value=1024, description="1024 ppb VOC concentration"
-        )
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0x00, 0x04]), expected_value=1024, description="1024 ppb VOC concentration"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0xC8, 0x00]), expected_value=200, description="200 ppb VOC concentration"
+            ),
+        ]
 
     def test_voc_concentration_parsing(self, characteristic: VOCConcentrationCharacteristic) -> None:
         """Test VOC concentration characteristic parsing."""

--- a/tests/gatt/characteristics/test_voltage.py
+++ b/tests/gatt/characteristics/test_voltage.py
@@ -19,9 +19,13 @@ class TestVoltageCharacteristic(CommonCharacteristicTests):
         return "2B18"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData | list[CharacteristicTestData]:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         # 1/64 V resolution, so e.g. 3.0 V = 192 (0x00C0)
-        # Test a typical value: 3.0 V
-        return CharacteristicTestData(
-            input_data=bytearray([0xC0, 0x00]), expected_value=3.0, description="3.0 V (0x00C0, 1/64 V resolution)"
-        )
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([0xC0, 0x00]), expected_value=3.0, description="3.0 V (0x00C0, 1/64 V resolution)"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([0x00, 0x01]), expected_value=4.0, description="4.0 V (0x0100, 1/64 V resolution)"
+            ),
+        ]

--- a/tests/gatt/characteristics/test_wind_chill.py
+++ b/tests/gatt/characteristics/test_wind_chill.py
@@ -23,11 +23,16 @@ class TestWindChillCharacteristic(CommonCharacteristicTests):
         return "2A79"
 
     @pytest.fixture
-    def valid_test_data(self) -> CharacteristicTestData:
+    def valid_test_data(self) -> list[CharacteristicTestData]:
         """Valid wind chill test data."""
-        return CharacteristicTestData(
-            input_data=bytearray([256 - 15]), expected_value=-15.0, description="-15°C wind chill"
-        )
+        return [
+            CharacteristicTestData(
+                input_data=bytearray([256 - 15]), expected_value=-15.0, description="-15°C wind chill"
+            ),
+            CharacteristicTestData(
+                input_data=bytearray([256 - 25]), expected_value=-25.0, description="-25°C wind chill"
+            ),
+        ]
 
     def test_wind_chill_parsing(self, characteristic: WindChillCharacteristic) -> None:
         """Test wind chill characteristic parsing."""


### PR DESCRIPTION
This pull request adds support for several Bluetooth SIG Alert Notification and Time-related GATT characteristics to the `bluetooth_sig.gatt.characteristics` module. It introduces new characteristic classes, each with robust encode/decode logic and schema validation, and updates the module exports for backward compatibility. The main focus is on expanding support for Alert Level, Alert Notification Control Point, Current Time, and New Alert characteristics.

**New Alert and Notification Characteristics:**

* Added `AlertLevelCharacteristic` class, with an `AlertLevel` enum and strict validation for encoding/decoding alert levels as defined by the Bluetooth SIG.
* Added `AlertNotificationControlPointCharacteristic` and associated data struct, enabling parsing and encoding of control point commands for alert notification services.
* Added `NewAlertCharacteristic` with a data struct for parsing and encoding new alert notifications, including category, count, and optional text, with validation for text length and category.

**New Time-related Characteristic:**

* Added `CurrentTimeCharacteristic` and its data struct, supporting full parsing and encoding of the 10-byte Current Time characteristic, including date/time, day of week, fractions of a second, and adjustment reason bitfields.

**Module and Export Updates:**

* Updated `__init__.py` to import and export all new characteristic classes for backward compatibility, ensuring they are available for use elsewhere in the codebase. [[1]](diffhunk://#diff-6c7695aaadd7f0b016f90ebfbbee5c1980644d7a13dab98eab682a09b0afef1cR12-R15) [[2]](diffhunk://#diff-6c7695aaadd7f0b016f90ebfbbee5c1980644d7a13dab98eab682a09b0afef1cR32) [[3]](diffhunk://#diff-6c7695aaadd7f0b016f90ebfbbee5c1980644d7a13dab98eab682a09b0afef1cR77) [[4]](diffhunk://#diff-6c7695aaadd7f0b016f90ebfbbee5c1980644d7a13dab98eab682a09b0afef1cR90) [[5]](diffhunk://#diff-6c7695aaadd7f0b016f90ebfbbee5c1980644d7a13dab98eab682a09b0afef1cR99-R110) [[6]](diffhunk://#diff-6c7695aaadd7f0b016f90ebfbbee5c1980644d7a13dab98eab682a09b0afef1cR129-R130) [[7]](diffhunk://#diff-6c7695aaadd7f0b016f90ebfbbee5c1980644d7a13dab98eab682a09b0afef1cR146) [[8]](diffhunk://#diff-6c7695aaadd7f0b016f90ebfbbee5c1980644d7a13dab98eab682a09b0afef1cR183) [[9]](diffhunk://#diff-6c7695aaadd7f0b016f90ebfbbee5c1980644d7a13dab98eab682a09b0afef1cR195-R211)