### PR TITLE
Documentation drift batch: Python version, characteristic counts, issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-task.md
+++ b/.github/ISSUE_TEMPLATE/general-task.md
@@ -6,7 +6,7 @@ labels: ['enhancement']
 assignees: []
 ---
 
-## 🎯 Task Description
+## Task Description
 
 **Brief Summary:**
 <!-- Clearly describe what needs to be done -->
@@ -14,7 +14,7 @@ assignees: []
 **Motivation:**
 <!-- Why is this task needed? What problem does it solve? -->
 
-## 📋 Implementation Requirements
+## Implementation Requirements
 
 ### Core Changes
 
@@ -30,12 +30,11 @@ assignees: []
 - [ ] Use descriptive variable and function names
 - [ ] Follow the project's architectural patterns
 
-## 🧪 Testing Requirements
+## Testing Requirements
 
 ### Unit Tests (MANDATORY)
 
 - [ ] Create/update unit tests for all new functionality
-- [ ] Ensure 100% test coverage for new code
 - [ ] Test both success and failure scenarios
 - [ ] Add edge case testing (empty inputs, boundary values, etc.)
 - [ ] Use appropriate test fixtures and mocking
@@ -43,7 +42,6 @@ assignees: []
 ### Integration Tests
 
 - [ ] Test integration with existing components
-- [ ] Verify compatibility with Home Assistant integration
 - [ ] Test real device scenarios if applicable
 - [ ] Validate registry validation tests pass
 
@@ -53,7 +51,7 @@ assignees: []
 - [ ] All tests must pass with 0 failures
 - [ ] No test warnings or deprecation notices
 
-## 🔍 Code Quality Validation
+## Code Quality Validation
 
 ### Script-Based Formatting and Linting (MANDATORY)
 
@@ -61,33 +59,10 @@ assignees: []
 
 - [ ] Run: `./scripts/format.sh --fix` (fix all formatting issues)
 - [ ] Run: `./scripts/format.sh --check` (verify formatting is correct)
-- [ ] Run: `./scripts/lint.sh --all` (run all linting checks)
-- [ ] **ALL linting checks MUST pass: flake8 + pylint 10.00/10 + shellcheck**
+- [ ] Run: `./scripts/lint.sh --all` (run all linting checks — ruff, mypy, shellcheck)
 - [ ] **Zero violations allowed in any linting tool**
 
-### Individual Tool Validation (For Debugging)
-
-- [ ] Run: `./scripts/lint.sh --flake8` (style checking)
-- [ ] Run: `./scripts/lint.sh --pylint` (code analysis - MUST score 10.00/10)
-- [ ] Run: `./scripts/lint.sh --shellcheck` (shell script validation)
-- [ ] Run: `./scripts/format.sh --black` (Python code formatting check)
-- [ ] Run: `./scripts/format.sh --isort` (import sorting check)
-
-### Legacy Commands (Deprecated - Use Scripts Above)
-
-- [ ] ~~Run: `python -m black src/ tests/` (format code)~~
-- [ ] ~~Run: `python -m flake8 src/ tests/` (style checking)~~
-- [ ] ~~Run: `python -m pylint src/ble_gatt_device` (code analysis)~~
-- [ ] **Use `./scripts/format.sh` and `./scripts/lint.sh` instead**
-
-### Manual Validation
-
-- [ ] Run: `find src -name "*.py" -exec python -m py_compile {} \;` (syntax check)
-- [ ] Run: `python -c "import ble_gatt_device; print('✅ Import successful')"`
-- [ ] Test import of any new modules/classes
-- [ ] Verify no import errors or circular dependencies
-
-## 🚀 GitHub Workflow Compliance
+## GitHub Workflow Compliance
 
 ### CI/CD Requirements (MANDATORY)
 
@@ -105,51 +80,45 @@ Before creating pull request, run these commands:
 source .venv/bin/activate
 
 # MANDATORY: Format and validate code using scripts
-./scripts/format.sh --fix           # Fix all formatting issues
-./scripts/format.sh --check         # Verify formatting is correct
-./scripts/lint.sh --all             # Run ALL linting checks (flake8 + pylint + shellcheck)
+./scripts/format.sh --fix
+./scripts/format.sh --check
+./scripts/lint.sh --all
 
 # Run comprehensive tests
 python -m pytest tests/ -v
 
 # Manual validation
-find src -name "*.py" -exec python -m py_compile {} \;
-python -c "import ble_gatt_device; print('✅ Framework ready')"
+python -c "import bluetooth_sig; print('Import successful')"
 ```
 
 **CRITICAL: All format and lint scripts must pass with zero issues before creating pull request.**
 
-## 📁 Files to Modify/Create
+## Files to Modify/Create
 
 ### Expected File Changes
 
-- [ ] `src/ble_gatt_device/...` <!-- List specific files -->
-- [ ] `tests/test_...` <!-- List test files -->
+- [ ] `src/bluetooth_sig/...` <!-- List specific files -->
+- [ ] `tests/...` <!-- List test files -->
 - [ ] Update relevant `__init__.py` files for new modules
 - [ ] Update documentation if needed
 
 ### Registry Updates (if applicable)
 
-- [ ] Update `src/ble_gatt_device/gatt/services/__init__.py`
-- [ ] Update `src/ble_gatt_device/gatt/characteristics/__init__.py`
+- [ ] Regenerate lazy exports if GATT modules added: `python scripts/generate_lazy_exports.py`
 - [ ] Ensure proper registration in respective registries
 
-## ✅ Definition of Done
+## Definition of Done
 
 ### Functional Requirements
 
 - [ ] All specified functionality is implemented
 - [ ] Code follows project architectural patterns
 - [ ] No breaking changes to existing functionality
-- [ ] Home Assistant integration works correctly
 
 ### Quality Gate (ALL MUST PASS)
 
 - [ ] **Script-based format check passes: `./scripts/format.sh --check`**
 - [ ] **Script-based lint check passes: `./scripts/lint.sh --all`**
-- [ ] **Pylint score: 10.00/10**
-- [ ] **Zero flake8 violations**
-- [ ] **Zero shellcheck issues**
 - [ ] **All tests pass: 0 failures**
 - [ ] **All GitHub workflows pass**
 - [ ] **No import errors or syntax issues**
@@ -161,7 +130,7 @@ python -c "import ble_gatt_device; print('✅ Framework ready')"
 - [ ] Include usage examples in docstrings
 - [ ] Document any new configuration options
 
-## 🔗 Related Information
+## Related Information
 
 **Dependencies:**
 <!-- List any dependencies on other issues or external factors -->
@@ -178,7 +147,7 @@ python -c "import ble_gatt_device; print('✅ Framework ready')"
 **Breaking Changes:**
 <!-- Note if this introduces any breaking changes -->
 
-## 🎯 Success Criteria
+## Success Criteria
 
 **The task is complete when:**
 
@@ -194,10 +163,9 @@ python -c "import ble_gatt_device; print('✅ Framework ready')"
 
 - **MANDATORY**: Run `./scripts/format.sh --fix` and `./scripts/lint.sh --all` after implementation
 - **TASK NOT COMPLETE**: Until all script-based quality checks pass with zero issues
-- Follow the BLE GATT Device project's existing patterns and architecture
+- Follow the bluetooth-sig library's existing patterns and architecture
 - Use the bluetooth_sig submodule for UUID lookups (check YAML files above)
-- Ensure all characteristics implement proper `decode_value()` methods with appropriate data types
-- Follow the 4-stage UUID name resolution system
+- Ensure all characteristics implement proper decode/encode methods with appropriate data types
 - Test against real device scenarios when possible
 - Maintain backward compatibility with existing implementations
 - Reference Bluetooth SIG specifications for data formats and units

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A pure Python library for Bluetooth SIG standards interpretation, providing comp
 - ✅ **Standards-Based**: Official Bluetooth SIG YAML registry with automatic UUID resolution
 - ✅ **Type-Safe**: Characteristic classes provide compile-time type checking; UUID strings return dynamic types
 - ✅ **Modern Python**: msgspec-based design with Python 3.10+ compatibility
-- ✅ **Comprehensive**: Support for 200+ GATT characteristics across multiple service categories
+- ✅ **Comprehensive**: 500+ assigned SIG characteristic UUIDs with ~96% Python parser coverage (see `scripts/gatt_coverage_report.py`)
 - ✅ **Flexible Validation**: Enable/disable validation per-characteristic for testing or debugging
 - ✅ **Framework Agnostic**: Works with any BLE library (bleak, simplepyble, etc.)
 
@@ -73,7 +73,7 @@ for uuid in discovered_uuids:
 
 | Feature | Description |
 | --- | --- |
-| **Characteristic Parsing** | Decode/encode 200+ GATT characteristics with type safety |
+| **Characteristic Parsing** | Decode/encode 500+ assigned SIG characteristics (~96% parser coverage) with type safety |
 | **Service Validation** | Check device compliance against SIG service specifications |
 | **Advertising Parsing** | Extract device name, service UUIDs, manufacturer data from PDUs |
 | **Device Abstraction** | High-level API combining connection management, parsing, and caching |
@@ -188,7 +188,7 @@ Enables high-level Bluetooth applications without low-level expertise:
 - ✅ **Automatic encoding/decoding** - Converts between raw bytes and typed Python objects using standards-compliant parsing
 - ✅ **Type-safe data structures** - Returns structured data objects instead of raw byte arrays (e.g., `VectorData`, `TemperatureMeasurement`)
 - ✅ **Framework-agnostic design** - Works with any BLE library (bleak, simplepyble, etc.) using a common connection manager interface
-- ✅ **Standards-based parsing** - 200+ GATT characteristics according to official Bluetooth SIG specifications
+- ✅ **Standards-based parsing** - 500+ assigned SIG characteristics with parsers for ~96% of UUIDs per coverage report
 - ✅ **Extensible** - Supports custom characteristics and services with the same type-safe patterns
 
 ## What This Library Does NOT Do
@@ -230,7 +230,7 @@ async with BleakClient(address) as client:
 
 ## Supported Characteristics
 
-200+ GATT characteristics across multiple categories:
+500+ assigned SIG characteristic UUIDs (~96% with Python parsers) across multiple categories:
 
 - **Battery Service**: Level, Power State
 - **Environmental Sensing**: Temperature, Humidity, Pressure, Air Quality

--- a/docs/source/explanation/architecture/overview.md
+++ b/docs/source/explanation/architecture/overview.md
@@ -65,7 +65,7 @@ graph TB
 
     subgraph Char["Characteristic Parsing"]
         B[BaseCharacteristic<br/>Abstract base]
-        S[70+ SIG Characteristics]
+        S[500+ SIG Characteristics<br/>~96% parsers]
         C[Custom Characteristics]
     end
 

--- a/docs/source/explanation/architecture/overview.md
+++ b/docs/source/explanation/architecture/overview.md
@@ -65,7 +65,7 @@ graph TB
 
     subgraph Char["Characteristic Parsing"]
         B[BaseCharacteristic<br/>Abstract base]
-        S[500+ SIG Characteristics<br/>~96% parsers]
+        S[500+ assigned UUIDs<br/>~96% parsers]
         C[Custom Characteristics]
     end
 

--- a/docs/source/explanation/limitations.md
+++ b/docs/source/explanation/limitations.md
@@ -63,7 +63,7 @@ ______________________________________________________________________
 - Resource-constrained environments
 - Server/peripheral role
 
-Requires Python 3.9+ runtime with standard library.
+Requires Python 3.10+ runtime with standard library.
 
 ______________________________________________________________________
 

--- a/docs/source/explanation/what-it-solves.md
+++ b/docs/source/explanation/what-it-solves.md
@@ -1,6 +1,6 @@
 # What Problems It Solves
 
-This library addresses specific pain points when working with Bluetooth Low Energy (BLE) devices and Bluetooth SIG specifications.
+This library addresses specific pain points when working with Bluetooth Low Energy (BLE) devices and Bluetooth SIG specifications. Its core mission is **SIG payload parse and encode without deep UUID knowledge**—turn raw GATT bytes into typed, validated values (and back) using the official registry, not hand-maintained mappings. Downstream integrators can add vendor-specific parsers via the extension model ([issue #198](https://github.com/RonanB96/bluetooth-sig-python/issues/198)).
 
 ## Problem 1: Standards Interpretation Complexity
 
@@ -56,7 +56,7 @@ print(f"Temperature: {result}°C")  # Temperature: 2.6°C
 
 ### ✅ What We Solve (Standards Interpretation)
 
-- **Automatic standards compliance** - All 70+ characteristics follow official specs
+- **Automatic standards compliance** - 500+ assigned characteristic UUIDs with ~96% Python parser coverage (run `scripts/gatt_coverage_report.py` for current counts)
 - **Unit conversion handling** - Correct scaling factors applied automatically
 - **Edge case management** - Special values and sentinels handled correctly
 - **Validation** - Input data validated before parsing
@@ -348,7 +348,7 @@ ______________________________________________________________________
 | Type safety | Raw bytes/dicts | Typed msgspec structs |
 | Framework lock-in | Library-specific APIs | Works with any BLE library |
 | Maintenance | You maintain | Community maintained |
-| Complex parsing | Custom logic for each | Built-in for 70+ characteristics |
+| Complex parsing | Custom logic for each | Built-in parsers for ~96% of assigned SIG characteristics |
 | Validation | Manual checks | Automatic validation |
 | Documentation | Write your own | Comprehensive docs |
 


### PR DESCRIPTION
## Summary
- Fix Python version in `limitations.md` (3.10+, matching `pyproject.toml`)
- Unify characteristic coverage language across README, what-it-solves, and architecture overview (~500 assigned UUIDs, ~96% parser coverage per coverage script)
- State core product intent (SIG payload parse/encode without deep UUID knowledge) in what-it-solves
- Refresh `.github/ISSUE_TEMPLATE/general-task.md` to use `bluetooth-sig`, ruff/mypy, and current QA commands (removed Home Assistant / flake8 / ble_gatt_device references)
- Link downstream custom parser extension model to #198

## Test plan
- [x] `./scripts/format.sh --check`
- [x] `./scripts/lint.sh --all`
- [x] `python -m pytest tests/ -v`

Fixes #199

Made with [Cursor](https://cursor.com)