### PR TITLE
Document maintainer workflow for SIG spec validation

### DIFF
--- a/docs/source/how-to/adding-characteristics.md
+++ b/docs/source/how-to/adding-characteristics.md
@@ -212,6 +212,7 @@ If you've added a standard Bluetooth SIG characteristic,
 consider contributing it back:
 
 1. Ensure your implementation follows the official specification
+1. For service-level SIG table checks, see [SIG Implementation Checks](sig-implementation-checks.md)
 1. Add comprehensive tests
 1. Add proper docstrings
 1. Regenerate lazy export maps: `python scripts/generate_lazy_exports.py`

--- a/docs/source/how-to/contributing.md
+++ b/docs/source/how-to/contributing.md
@@ -94,63 +94,9 @@ Before you submit a pull request, check that it meets these guidelines:
 1. If the pull request adds functionality, the docs should be updated. Put your new functionality into a function with a docstring, and add the feature to the list in README.md.
 1. The pull request should work for Python 3.10+. Tests run in GitHub Actions on every pull request to the main branch, make sure that the tests pass for all supported Python versions.
 
-## Maintainer Workflow: SIG Spec Validation
+## Maintainer checks
 
-These steps are for **maintainers** validating that Python service implementations match Bluetooth SIG specification tables. They are **not** CI gates—SIG HTML fetch requires manual steps and local spec extracts.
-
-### Prerequisites
-
-- Development environment installed (`pip install -e ".[dev]"`)
-- Familiarity with [Fetching SIG Specs](https://github.com/RonanB96/bluetooth-sig-python/blob/main/.github/copilot-instructions.md#fetching-sig-specs) in `.github/copilot-instructions.md`
-
-### 1. Extract spec text into `.tmp/`
-
-1. Find the service spec slug on [Bluetooth SIG Specifications](https://www.bluetooth.com/specifications/specs/).
-2. Follow the copilot instructions to resolve the public HTML URL (one spec at a time; do not guess URL patterns).
-3. Save plain-text extracts of the characteristics table section as `.tmp/{service-name}_spec.txt` (filename must end with `_spec.txt`).
-
-The `.tmp/` directory is gitignored—spec extracts stay local.
-
-### 2. Run the validation script
-
-```bash
-python scripts/validate_service_characteristics_from_specs.py
-python scripts/validate_service_characteristics_from_specs.py --verbose
-python scripts/validate_service_characteristics_from_specs.py --spec-dir .tmp --pattern '*_spec.txt'
-```
-
-The script compares parsed spec tables to `src/bluetooth_sig/gatt/services/` implementations. Exit code **0** means all matched services align; **1** means mismatches or unmatched spec files.
-
-Interpret the summary:
-
-- **Service mismatches** — mandatory characteristics missing from Python, extra characteristics, or requirement-flag differences
-- **Unmatched specs** — spec file could not be mapped to a service class (often naming or out-of-scope domains)
-- **Parse skips** — file had no parseable characteristics table
-
-### 3. Run the coverage companion
-
-```bash
-python scripts/gatt_coverage_report.py
-python scripts/gatt_coverage_report.py --verbose
-```
-
-This reports YAML → Python gaps for characteristics, services, and descriptors. Use it to prioritize implementation backlog.
-
-### 4. When to file issues vs mark out-of-scope
-
-File implementation issues when a **BLE GATT** service or characteristic is in scope but missing or wrong. Mark out-of-scope (do not block on validation) for:
-
-- **Mesh networking** — different protocol stack ([registry coverage](../reference/registry-coverage.md))
-- **Classic Bluetooth / SDP** — `service_discovery/` registries
-- **LE Audio / profile-triggered registries** — loaded as corresponding GATT services are implemented
-
-Run ``python scripts/gatt_coverage_report.py --verbose`` for the current characteristic/service backlog.
-
-See [Registry Coverage](../reference/registry-coverage.md) for the full out-of-scope list and priority roadmap.
-
-### Downstream custom parsers
-
-Integrators can register vendor-specific parsers outside this repo; see [Adding Characteristics — companion packages](adding-characteristics.md) (extension model).
+When auditing GATT service implementations against SIG specification tables, see [SIG Implementation Checks](sig-implementation-checks.md).
 
 ## Tips
 

--- a/docs/source/how-to/contributing.md
+++ b/docs/source/how-to/contributing.md
@@ -94,6 +94,63 @@ Before you submit a pull request, check that it meets these guidelines:
 1. If the pull request adds functionality, the docs should be updated. Put your new functionality into a function with a docstring, and add the feature to the list in README.md.
 1. The pull request should work for Python 3.10+. Tests run in GitHub Actions on every pull request to the main branch, make sure that the tests pass for all supported Python versions.
 
+## Maintainer Workflow: SIG Spec Validation
+
+These steps are for **maintainers** validating that Python service implementations match Bluetooth SIG specification tables. They are **not** CI gates—SIG HTML fetch requires manual steps and local spec extracts.
+
+### Prerequisites
+
+- Development environment installed (`pip install -e ".[dev]"`)
+- Familiarity with [Fetching SIG Specs](https://github.com/RonanB96/bluetooth-sig-python/blob/main/.github/copilot-instructions.md#fetching-sig-specs) in `.github/copilot-instructions.md`
+
+### 1. Extract spec text into `.tmp/`
+
+1. Find the service spec slug on [Bluetooth SIG Specifications](https://www.bluetooth.com/specifications/specs/).
+2. Follow the copilot instructions to resolve the public HTML URL (one spec at a time; do not guess URL patterns).
+3. Save plain-text extracts of the characteristics table section as `.tmp/{service-name}_spec.txt` (filename must end with `_spec.txt`).
+
+The `.tmp/` directory is gitignored—spec extracts stay local.
+
+### 2. Run the validation script
+
+```bash
+python scripts/validate_service_characteristics_from_specs.py
+python scripts/validate_service_characteristics_from_specs.py --verbose
+python scripts/validate_service_characteristics_from_specs.py --spec-dir .tmp --pattern '*_spec.txt'
+```
+
+The script compares parsed spec tables to `src/bluetooth_sig/gatt/services/` implementations. Exit code **0** means all matched services align; **1** means mismatches or unmatched spec files.
+
+Interpret the summary:
+
+- **Service mismatches** — mandatory characteristics missing from Python, extra characteristics, or requirement-flag differences
+- **Unmatched specs** — spec file could not be mapped to a service class (often naming or out-of-scope domains)
+- **Parse skips** — file had no parseable characteristics table
+
+### 3. Run the coverage companion
+
+```bash
+python scripts/gatt_coverage_report.py
+python scripts/gatt_coverage_report.py --verbose
+```
+
+This reports YAML → Python gaps for characteristics, services, and descriptors. Use it to prioritize implementation backlog.
+
+### 4. When to file issues vs mark out-of-scope
+
+File implementation issues when a **BLE GATT** service or characteristic is in scope but missing or wrong. Mark out-of-scope (do not block on validation) for:
+
+- **Mesh networking** — different protocol stack ([registry coverage](../reference/registry-coverage.md))
+- **Classic Bluetooth / SDP** — `service_discovery/` registries
+- **Profile backlog** — e.g. Voice Assistant, Cookware characteristics not yet targeted by device scope
+- **LE Audio / profile-triggered registries** — loaded as corresponding GATT services are implemented
+
+See [Registry Coverage](../reference/registry-coverage.md) for the full out-of-scope list and priority roadmap.
+
+### Downstream custom parsers
+
+Integrators can register vendor-specific parsers outside this repo; see issue [#198](https://github.com/RonanB96/bluetooth-sig-python/issues/198) for the extension model (documentation in progress).
+
 ## Tips
 
 To run a subset of tests:

--- a/docs/source/how-to/contributing.md
+++ b/docs/source/how-to/contributing.md
@@ -142,14 +142,15 @@ File implementation issues when a **BLE GATT** service or characteristic is in s
 
 - **Mesh networking** — different protocol stack ([registry coverage](../reference/registry-coverage.md))
 - **Classic Bluetooth / SDP** — `service_discovery/` registries
-- **Profile backlog** — e.g. Voice Assistant, Cookware characteristics not yet targeted by device scope
 - **LE Audio / profile-triggered registries** — loaded as corresponding GATT services are implemented
+
+Run ``python scripts/gatt_coverage_report.py --verbose`` for the current characteristic/service backlog.
 
 See [Registry Coverage](../reference/registry-coverage.md) for the full out-of-scope list and priority roadmap.
 
 ### Downstream custom parsers
 
-Integrators can register vendor-specific parsers outside this repo; see issue [#198](https://github.com/RonanB96/bluetooth-sig-python/issues/198) for the extension model (documentation in progress).
+Integrators can register vendor-specific parsers outside this repo; see [Adding Characteristics — companion packages](adding-characteristics.md) (extension model).
 
 ## Tips
 

--- a/docs/source/how-to/index.md
+++ b/docs/source/how-to/index.md
@@ -18,6 +18,7 @@ Practical guides to solve specific problems and accomplish goals with the Blueto
 ## Extending the Library
 
 - **[Adding Characteristics](adding-characteristics.md)** — Add new SIG-defined characteristics
+- **[SIG Implementation Checks](sig-implementation-checks.md)** — Maintainer scripts for spec tables and registry backlog
 - **[Testing](testing.md)** — Test your BLE applications without hardware
 - **[Contributing](contributing.md)** — Contribute code, docs, or bug reports
 
@@ -52,6 +53,7 @@ characteristics
 services
 advertising-parsing
 adding-characteristics
+sig-implementation-checks
 performance-tuning
 testing
 migration

--- a/docs/source/how-to/sig-implementation-checks.md
+++ b/docs/source/how-to/sig-implementation-checks.md
@@ -10,9 +10,7 @@ What is implemented, planned, and out of scope is documented in [Registry Covera
 
 `scripts/validate_service_characteristics_from_specs.py` compares characteristics tables from extracted spec text to classes under `src/bluetooth_sig/gatt/services/`.
 
-1. Fetch spec HTML and prepare text extracts using **Fetching SIG Specs** in [`.github/copilot-instructions.md`](https://github.com/RonanB96/bluetooth-sig-python/blob/main/.github/copilot-instructions.md#fetching-sig-specs).
-1. Save extracts under `.tmp/` as `*_spec.txt` (gitignored).
-1. Run the script; see its module docstring and `python scripts/validate_service_characteristics_from_specs.py --help` for file layout, options, and exit codes.
+Fetch spec HTML using **Fetching SIG Specs** in [`.github/copilot-instructions.md`](https://github.com/RonanB96/bluetooth-sig-python/blob/main/.github/copilot-instructions.md#fetching-sig-specs). Prepare text extracts and run the script; see its module docstring and `python scripts/validate_service_characteristics_from_specs.py --help` for file layout, `--spec-dir`, `--pattern`, and exit codes.
 
 ## YAML coverage report
 

--- a/docs/source/how-to/sig-implementation-checks.md
+++ b/docs/source/how-to/sig-implementation-checks.md
@@ -1,0 +1,29 @@
+# SIG Implementation Checks
+
+Maintainers use two repository scripts to cross-check GATT implementations against Bluetooth SIG sources. These are optional, local checks—not part of the contributor quality gates in [Contributing](contributing.md).
+
+## Scope and backlog
+
+What is implemented, planned, and out of scope is documented in [Registry Coverage](../reference/registry-coverage.md). Use that reference when deciding whether a gap belongs in this repository.
+
+## Spec table validation
+
+`scripts/validate_service_characteristics_from_specs.py` compares characteristics tables from extracted spec text to classes under `src/bluetooth_sig/gatt/services/`.
+
+1. Fetch spec HTML and prepare text extracts using **Fetching SIG Specs** in [`.github/copilot-instructions.md`](https://github.com/RonanB96/bluetooth-sig-python/blob/main/.github/copilot-instructions.md#fetching-sig-specs).
+1. Save extracts under `.tmp/` as `*_spec.txt` (gitignored).
+1. Run the script; see its module docstring and `python scripts/validate_service_characteristics_from_specs.py --help` for file layout, options, and exit codes.
+
+## YAML coverage report
+
+`scripts/gatt_coverage_report.py` reports YAML-defined UUIDs versus Python implementations for characteristics, services, and descriptors. See `python scripts/gatt_coverage_report.py --help` for usage.
+
+## Runtime validation (applications)
+
+For checking a concrete device service at runtime, use `validate_service()` on service classes—see [Service Validation](services.md#service-validation). That API is separate from the maintainer spec-table script above.
+
+## See Also
+
+- [Adding Characteristics](adding-characteristics.md) — Implement new characteristics and services
+- [Registry Coverage](../reference/registry-coverage.md) — Implementation status and roadmap
+- [Contributing](contributing.md) — Pull requests and quality gates

--- a/docs/source/reference/registry-coverage.md
+++ b/docs/source/reference/registry-coverage.md
@@ -136,3 +136,4 @@ Profile registries added when corresponding characteristics are implemented. No 
 - [Registry System Architecture](../explanation/architecture/registry-system.md) — Implementation details
 - [Supported Characteristics](characteristics.md) — Full characteristic list
 - [Limitations](../explanation/limitations.md) — Scope boundaries
+- [SIG Implementation Checks](../how-to/sig-implementation-checks.md) — Maintainer scripts for spec tables and YAML backlog


### PR DESCRIPTION
## Summary
- Add **Maintainer Workflow: SIG Spec Validation** section to `docs/source/how-to/contributing.md`
- Document spec extract steps (`.tmp/*_spec.txt`), validation script usage, and coverage companion script
- Link to copilot spec-fetch instructions and registry-coverage out-of-scope list (Mesh, Classic, profile backlog)
- Clarify this is maintainer-only, not a CI gate

## Test plan
- [x] `./scripts/format.sh --check`
- [x] `./scripts/lint.sh --all`
- [x] `python -m pytest tests/ -v`

Fixes #202

Made with [Cursor](https://cursor.com)