### PR TITLE
Document downstream custom parser packages (extension model)

### DIFF
--- a/docs/source/explanation/limitations.md
+++ b/docs/source/explanation/limitations.md
@@ -26,6 +26,8 @@ ______________________________________________________________________
 
 The library works at the application layer. Lower-level protocols are handled by your BLE backend (bleak, simplepyble, etc.) and OS.
 
+Vendor-specific characteristic parsers belong in [companion packages](../how-to/adding-characteristics.md#building-a-companion-package), not in this repository.
+
 ______________________________________________________________________
 
 ## ❌ Hardware Abstraction

--- a/docs/source/how-to/adding-characteristics.md
+++ b/docs/source/how-to/adding-characteristics.md
@@ -7,8 +7,40 @@ Learn how to extend the library with custom or newly standardized characteristic
 You might need to add a characteristic when:
 
 1. A new Bluetooth SIG standard characteristic is released
-1. You're working with a vendor-specific characteristic
-1. You need custom parsing for a specific use case
+1. You need custom parsing for a proprietary UUID in **your own package** (see [Building a companion package](#building-a-companion-package))
+1. You need custom parsing for a specific use case in downstream code
+
+## Building a companion package
+
+**This repository does not host device-specific vendor parsers.** Nordic, Govee, and other proprietary UUID implementations belong in **separate downstream packages** that depend on `bluetooth-sig`.
+
+Typical companion-package workflow:
+
+1. Create a PyPI package (e.g. `my-device-parsers`) with `bluetooth-sig` as a dependency.
+2. Define `CustomBaseCharacteristic` subclasses with your proprietary UUIDs and decode/encode logic.
+3. At application startup, register each class:
+
+```python
+# SKIP: Companion package example — my_device_parsers is an external package
+from bluetooth_sig import BluetoothSIGTranslator
+from my_device_parsers import VendorSensorCharacteristic
+
+translator = BluetoothSIGTranslator()
+translator.register_custom_characteristic_class(
+    str(VendorSensorCharacteristic._info.uuid),
+    VendorSensorCharacteristic,
+    override=True,
+)
+```
+
+4. Use the translator or `Device` API as usual — registered classes participate in UUID lookup and batch parsing.
+
+Reference implementations:
+
+- `tests/integration/test_custom_registration.py` — registration and parse round-trip
+- `tests/gatt/characteristics/test_custom_characteristics.py` — custom characteristic patterns
+
+Contribute **SIG-standard** characteristics back to this repo; keep vendor-specific parsers in companion packages.
 
 ## Basic Structure
 
@@ -43,7 +75,7 @@ class MyCharacteristic(BaseCharacteristic):
 
 ## Custom Characteristics
 
-For vendor-specific characteristics, extend :class:`~bluetooth_sig.gatt.characteristics.custom.CustomBaseCharacteristic`:
+For vendor-specific characteristics in a **companion package**, extend :class:`~bluetooth_sig.gatt.characteristics.custom.CustomBaseCharacteristic`:
 
 ```python
 from bluetooth_sig.gatt.characteristics.custom import CustomBaseCharacteristic
@@ -221,6 +253,7 @@ See [Contributing Guide](contributing.md) for details.
 
 ## See Also
 
+- [Limitations](../explanation/limitations.md) — scope boundaries (vendor parsers live outside this repo)
 - [Architecture](../explanation/architecture/overview.md) - Understand the design
 - [Testing Guide](testing.md) - Testing best practices
 - [API Reference](../api/index.md) - GATT layer details

--- a/docs/source/how-to/adding-characteristics.md
+++ b/docs/source/how-to/adding-characteristics.md
@@ -12,33 +12,14 @@ You might need to add a characteristic when:
 
 ## Building a companion package
 
-**This repository does not host device-specific vendor parsers.** Nordic, Govee, and other proprietary UUID implementations belong in **separate downstream packages** that depend on `bluetooth-sig`.
+**This repository does not host device-specific vendor parsers.** Proprietary UUID implementations belong in **separate downstream packages** that depend on `bluetooth-sig`.
 
-Typical companion-package workflow:
+1. Create your python application with `bluetooth-sig` as a dependency.
+2. Implement `CustomBaseCharacteristic` subclasses using the [Custom Characteristics — runtime registration](characteristics.md#runtime-registration) pattern (`VendorSensorCharacteristic` decode, encode, and registry usage).
+3. Register each class at application startup with `BluetoothSIGTranslator.register_custom_characteristic_class()` — see [`CustomCharacteristicImpl`](https://github.com/RonanB96/bluetooth-sig-python/blob/main/tests/integration/test_custom_registration.py) and `test_translator_register_custom_characteristic` in that file.
+4. Use the translator or `Device` API as usual.
 
-1. Create a PyPI package (e.g. `my-device-parsers`) with `bluetooth-sig` as a dependency.
-2. Define `CustomBaseCharacteristic` subclasses with your proprietary UUIDs and decode/encode logic.
-3. At application startup, register each class:
-
-```python
-# SKIP: Companion package example — my_device_parsers is an external package
-from bluetooth_sig import BluetoothSIGTranslator
-from my_device_parsers import VendorSensorCharacteristic
-
-translator = BluetoothSIGTranslator()
-translator.register_custom_characteristic_class(
-    str(VendorSensorCharacteristic._info.uuid),
-    VendorSensorCharacteristic,
-    override=True,
-)
-```
-
-4. Use the translator or `Device` API as usual — registered classes participate in UUID lookup and batch parsing.
-
-Reference implementations:
-
-- `tests/integration/test_custom_registration.py` — registration and parse round-trip
-- `tests/gatt/characteristics/test_custom_characteristics.py` — custom characteristic patterns
+For dependent characteristics (calibration, sequence matching), see [`tests/integration/test_end_to_end.py`](https://github.com/RonanB96/bluetooth-sig-python/blob/main/tests/integration/test_end_to_end.py) (`CalibrationCharacteristic`, `SensorReadingCharacteristic`).
 
 Contribute **SIG-standard** characteristics back to this repo; keep vendor-specific parsers in companion packages.
 


### PR DESCRIPTION
## Summary
- Add **Building a companion package** section to `adding-characteristics.md`
- State explicitly that vendor/device-specific parsers belong in downstream PyPI packages, not this repo
- Link to integration tests as reference implementations
- Cross-link from `limitations.md`

## Test plan
- [x] Quality gates pass locally
- [x] Docs code block tests pass (companion example marked SKIP)

Fixes #198

Made with [Cursor](https://cursor.com)