### PR TITLE
Fix docs/API drift: descriptor_data and parse_characteristics batch flow

### DIFF
--- a/docs/source/explanation/architecture/internals.md
+++ b/docs/source/explanation/architecture/internals.md
@@ -674,7 +674,7 @@ Characteristics can access descriptor data through the `CharacteristicContext` w
 2. **Use if available**: Apply descriptor-based validation/formatting
 3. **Fall back to declarative**: Use class attributes if no descriptor present
 
-Batch :meth:`~bluetooth_sig.core.translator.BluetoothSIGTranslator.parse_characteristics` does not populate context descriptors automatically — read descriptors separately and attach them when single-value parsing requires them.
+This enables runtime validation that adapts to actual device capabilities. See the [BLE Integration Guide](../../how-to/ble-integration.md) for usage patterns.
 
 ## Exception Hierarchy
 

--- a/docs/source/explanation/architecture/internals.md
+++ b/docs/source/explanation/architecture/internals.md
@@ -668,13 +668,13 @@ description_desc = CharacteristicUserDescriptionDescriptor()
 
 ### Descriptor Access Pattern
 
-Characteristics can access descriptor data through the `CharacteristicContext`:
+Characteristics can access descriptor data through the `CharacteristicContext` when you supply descriptor bytes to :meth:`~bluetooth_sig.gatt.characteristics.base.BaseCharacteristic.parse_value`:
 
 1. **Check for descriptor**: Query context for Valid Range, Presentation Format, etc.
 2. **Use if available**: Apply descriptor-based validation/formatting
 3. **Fall back to declarative**: Use class attributes if no descriptor present
 
-This enables runtime validation that adapts to actual device capabilities. See the [BLE Integration Guide](../../how-to/ble-integration.md) for usage patterns.
+Batch :meth:`~bluetooth_sig.core.translator.BluetoothSIGTranslator.parse_characteristics` does not populate context descriptors automatically — read descriptors separately and attach them when single-value parsing requires them.
 
 ## Exception Hierarchy
 

--- a/docs/source/how-to/migration.md
+++ b/docs/source/how-to/migration.md
@@ -452,7 +452,7 @@ await device.disconnect()
 - ✅ Keep your BLE client code (Bleak/SimplePyBLE) unchanged
 - ✅ After each read or in notification callbacks, call `parse_characteristic(uuid, bytes)`
 - ✅ For multiple related characteristics, call `parse_characteristics({uuid: bytes})`
-- ✅ Include descriptors when needed by building a :class:`~bluetooth_sig.gatt.context.CharacteristicContext` for single-value parsing (batch parse does not accept descriptor maps yet)
+- ✅ Include descriptors when needed (via adapters or `descriptor_data` mapping)
 - ✅ For larger apps, adopt a `ConnectionManagerProtocol` + `Device` pattern
 
 ## Where are the example adapters?
@@ -524,7 +524,7 @@ for service in peripheral.services():
 
 - **Unknown UUID**: Ensure you're using the correct SIG UUID (short or full).
 - **Parse failed**: Check spec constraints (length, range); `result.error_message` explains the issue.
-- **Descriptor-dependent parsing**: Read descriptor bytes separately and pass them via :class:`~bluetooth_sig.gatt.context.CharacteristicContext` to :meth:`~bluetooth_sig.gatt.characteristics.base.BaseCharacteristic.parse_value`. Batch :meth:`~bluetooth_sig.core.translator.BluetoothSIGTranslator.parse_characteristics` does not accept a descriptor map yet.
+- **Descriptor-dependent parsing**: Pass descriptor bytes via `descriptor_data` or use the example adapters.
 - **Advertising data**: Use `AdvertisingPDUParser` for parsing advertising packets—see [Advertising Parsing Guide](advertising-parsing.md).
 - **Type hints not working**: Ensure you're using Python 3.10+ for best type checking support.
 

--- a/docs/source/how-to/migration.md
+++ b/docs/source/how-to/migration.md
@@ -411,9 +411,10 @@ values = {gm_uuid: gm_bytes, gmc_uuid: gmc_bytes}
 
 batch = bleak_services_to_batch(services, values_by_uuid=values)
 char_data, desc_data = to_parse_inputs(batch)
-results = translator.parse_characteristics(
-    char_data, descriptor_data=desc_data
-)
+results = translator.parse_characteristics(char_data)
+# desc_data holds descriptor bytes if the adapter read them; wire manually via
+# CharacteristicContext when calling parse_value — batch parse ignores desc_data today.
+_ = desc_data
 ```
 
 **Note**: Example adapters are provided as references; update them as needed for your project/backend versions.
@@ -452,7 +453,7 @@ await device.disconnect()
 - ✅ Keep your BLE client code (Bleak/SimplePyBLE) unchanged
 - ✅ After each read or in notification callbacks, call `parse_characteristic(uuid, bytes)`
 - ✅ For multiple related characteristics, call `parse_characteristics({uuid: bytes})`
-- ✅ Include descriptors when needed (via adapters or `descriptor_data` mapping)
+- ✅ Include descriptors when needed by building a :class:`~bluetooth_sig.gatt.context.CharacteristicContext` for single-value parsing (batch parse does not accept descriptor maps yet)
 - ✅ For larger apps, adopt a `ConnectionManagerProtocol` + `Device` pattern
 
 ## Where are the example adapters?
@@ -524,7 +525,7 @@ for service in peripheral.services():
 
 - **Unknown UUID**: Ensure you're using the correct SIG UUID (short or full).
 - **Parse failed**: Check spec constraints (length, range); `result.error_message` explains the issue.
-- **Descriptor-dependent parsing**: Pass descriptor bytes via `descriptor_data` or use the example adapters.
+- **Descriptor-dependent parsing**: Read descriptor bytes separately and pass them via :class:`~bluetooth_sig.gatt.context.CharacteristicContext` to :meth:`~bluetooth_sig.gatt.characteristics.base.BaseCharacteristic.parse_value`. Batch :meth:`~bluetooth_sig.core.translator.BluetoothSIGTranslator.parse_characteristics` does not accept a descriptor map yet.
 - **Advertising data**: Use `AdvertisingPDUParser` for parsing advertising packets—see [Advertising Parsing Guide](advertising-parsing.md).
 - **Type hints not working**: Ensure you're using Python 3.10+ for best type checking support.
 

--- a/docs/source/how-to/migration.md
+++ b/docs/source/how-to/migration.md
@@ -414,7 +414,6 @@ char_data, desc_data = to_parse_inputs(batch)
 results = translator.parse_characteristics(char_data)
 # desc_data holds descriptor bytes if the adapter read them; wire manually via
 # CharacteristicContext when calling parse_value — batch parse ignores desc_data today.
-_ = desc_data
 ```
 
 **Note**: Example adapters are provided as references; update them as needed for your project/backend versions.

--- a/docs/source/how-to/usage.md
+++ b/docs/source/how-to/usage.md
@@ -281,7 +281,7 @@ If you prefer typed containers before calling the translator, use these types:
 
 - `bluetooth_sig.types.io.RawCharacteristicRead` — holds a single read (`uuid`, `raw_data`, optional `descriptors`, optional `properties`).
 - `bluetooth_sig.types.io.RawCharacteristicBatch` — a batch of reads.
-- `bluetooth_sig.types.io.to_parse_inputs(batch)` — converts a batch to the exact `(char_data, descriptor_data)` shapes accepted by `parse_characteristics`.
+- `bluetooth_sig.types.io.to_parse_inputs(batch)` — converts a batch to `(char_data, descriptor_data)` tuples for staging; pass `char_data` to `parse_characteristics` (descriptor bytes are not yet consumed by batch parse — see below).
 
 Example:
 
@@ -319,6 +319,9 @@ batch = RawCharacteristicBatch(
 
 char_data, descriptor_data = to_parse_inputs(batch)
 results = BluetoothSIGTranslator().parse_characteristics(char_data)
+# descriptor_data is available if you read descriptors separately; batch parse does not
+# accept descriptor_data yet — attach via CharacteristicContext when calling parse_value.
+_ = descriptor_data
 ```
 
 For BLE library integration patterns (bleak, simplepyble, etc.), see the [BLE Integration Guide](ble-integration.md) and [Migration Guide](migration.md).

--- a/docs/source/how-to/usage.md
+++ b/docs/source/how-to/usage.md
@@ -321,7 +321,6 @@ char_data, descriptor_data = to_parse_inputs(batch)
 results = BluetoothSIGTranslator().parse_characteristics(char_data)
 # descriptor_data is available if you read descriptors separately; batch parse does not
 # accept descriptor_data yet — attach via CharacteristicContext when calling parse_value.
-_ = descriptor_data
 ```
 
 For BLE library integration patterns (bleak, simplepyble, etc.), see the [BLE Integration Guide](ble-integration.md) and [Migration Guide](migration.md).

--- a/src/bluetooth_sig/types/io.py
+++ b/src/bluetooth_sig/types/io.py
@@ -47,13 +47,17 @@ class RawCharacteristicBatch(msgspec.Struct, kw_only=True):
 def to_parse_inputs(
     batch: RawCharacteristicBatch,
 ) -> tuple[dict[str, bytes], dict[str, dict[str, bytes]]]:
-    """Convert a :class:`RawCharacteristicBatch` to translator inputs.
+    """Convert a :class:`RawCharacteristicBatch` to staging inputs.
 
-    Returns a tuple of `(char_data, descriptor_data)` suitable for
-    `BluetoothSIGTranslator.parse_characteristics(char_data, descriptor_data=...)`.
+    Returns a tuple of `(char_data, descriptor_data)`:
 
-    - `char_data` is a mapping of UUID -> raw bytes
-    - `descriptor_data` is a nested mapping of char UUID -> (descriptor UUID -> raw bytes)
+    - `char_data` — mapping of characteristic UUID -> raw bytes; pass this to
+      :meth:`~bluetooth_sig.core.translator.BluetoothSIGTranslator.parse_characteristics`.
+    - `descriptor_data` — nested mapping of char UUID -> (descriptor UUID -> raw bytes).
+      Collected from :attr:`RawCharacteristicRead.descriptors` when present. Batch
+      parsing does not accept this mapping yet; use it when building a
+      :class:`~bluetooth_sig.gatt.context.CharacteristicContext` for single-value
+      :meth:`~bluetooth_sig.gatt.characteristics.base.BaseCharacteristic.parse_value` calls.
     """
     char_data: dict[str, bytes] = {}
     descriptor_data: dict[str, dict[str, bytes]] = {}


### PR DESCRIPTION
## Summary
- **Option A (minimal):** Align docs with actual API — `parse_characteristics(char_data, ctx=None)` only
- Update `usage.md`, `migration.md`, `internals.md`, and `io.py` docstrings
- Clarify `to_parse_inputs` returns descriptor bytes for staging/manual `CharacteristicContext` use, not batch parse

## Test plan
- [x] Quality gates pass locally
- [x] Full test suite green

Fixes #196

Made with [Cursor](https://cursor.com)