### PR TITLE
Deprecate peripheral/GATT-server API (PeripheralManagerProtocol)

### DIFF
--- a/docs/source/explanation/limitations.md
+++ b/docs/source/explanation/limitations.md
@@ -24,6 +24,12 @@ ______________________________________________________________________
 - Link layer implementation
 - GATT server/peripheral role
 
+:::{deprecated} 0.5.0
+``PeripheralDevice``, ``PeripheralManagerProtocol``, and related types in
+``bluetooth_sig.types.peripheral_types`` are deprecated and scheduled for removal.
+Use client-side :class:`~bluetooth_sig.device.device.Device` with SIG parse/encode.
+:::
+
 The library works at the application layer. Lower-level protocols are handled by your BLE backend (bleak, simplepyble, etc.) and OS.
 
 ______________________________________________________________________

--- a/examples/connection_managers/bless_peripheral.py
+++ b/examples/connection_managers/bless_peripheral.py
@@ -1,9 +1,5 @@
 """Bless-based peripheral manager for bluetooth-sig-python.
 
-.. deprecated:: 0.5.0
-    GATT server/peripheral examples are deprecated. This library focuses on
-    client-side SIG parse/encode; server role APIs are scheduled for removal.
-
 This module provides a bless backend implementation for creating BLE GATT
 servers that broadcast user-defined services and characteristics.
 

--- a/examples/connection_managers/bless_peripheral.py
+++ b/examples/connection_managers/bless_peripheral.py
@@ -1,5 +1,9 @@
 """Bless-based peripheral manager for bluetooth-sig-python.
 
+.. deprecated:: 0.5.0
+    GATT server/peripheral examples are deprecated. This library focuses on
+    client-side SIG parse/encode; server role APIs are scheduled for removal.
+
 This module provides a bless backend implementation for creating BLE GATT
 servers that broadcast user-defined services and characteristics.
 

--- a/src/bluetooth_sig/device/__init__.py
+++ b/src/bluetooth_sig/device/__init__.py
@@ -5,10 +5,6 @@ Additional composition-based subsystems are available for focused use cases:
 
 - DeviceAdvertising: Advertising packet interpretation
 - DeviceConnected: GATT connection operations (client/central role)
-
-.. deprecated:: 0.5.0
-    ``PeripheralDevice`` and ``PeripheralManagerProtocol`` are deprecated
-    (GATT server role out of scope) and scheduled for removal.
 """
 
 from __future__ import annotations

--- a/src/bluetooth_sig/device/__init__.py
+++ b/src/bluetooth_sig/device/__init__.py
@@ -1,4 +1,4 @@
-"""Device abstraction with advertising, connection, and peripheral subsystems.
+"""Device abstraction with advertising, connection, and client subsystems.
 
 The Device class provides a unified interface for BLE device operations.
 Additional composition-based subsystems are available for focused use cases:
@@ -6,7 +6,9 @@ Additional composition-based subsystems are available for focused use cases:
 - DeviceAdvertising: Advertising packet interpretation
 - DeviceConnected: GATT connection operations (client/central role)
 
-For server/peripheral role, see PeripheralManagerProtocol.
+.. deprecated:: 0.5.0
+    ``PeripheralDevice`` and ``PeripheralManagerProtocol`` are deprecated
+    (GATT server role out of scope) and scheduled for removal.
 """
 
 from __future__ import annotations

--- a/src/bluetooth_sig/device/peripheral.py
+++ b/src/bluetooth_sig/device/peripheral.py
@@ -1,21 +1,15 @@
 """Peripheral manager protocol for BLE GATT server adapters.
 
+.. deprecated:: 0.5.0
+    Peripheral/server APIs are out of scope for this library. Prefer client-side
+    :class:`~bluetooth_sig.device.device.Device` with parse/encode. These types
+    will be removed in a future release.
+
 Defines an async abstract base class that peripheral adapter implementations
 (bless, bluez_peripheral, etc.) must inherit from to create BLE GATT servers
 that broadcast services and characteristics.
 
-This is the server-side counterpart to ClientManagerProtocol. Where clients
-connect TO devices and READ/PARSE data, peripherals ARE devices that ENCODE
-and BROADCAST data for others to read.
-
 Adapters must provide async implementations of all abstract methods below.
-
-TODO: PeripheralDevice exists in peripheral_device.py with core functionality.
-    Remaining gaps to address (see ROADMAP.md Workstream F):
-    - Subscription management (on_subscribe/on_unsubscribe, subscribed_clients tracking)
-    - Client event callbacks (on_client_connected/on_client_disconnected)
-    - Read/write request handling (typed on_read_request/on_write_request)
-    - Descriptor hosting (CCCD, User Description, Presentation Format)
 """
 
 from __future__ import annotations
@@ -33,6 +27,10 @@ from bluetooth_sig.types.uuid import BluetoothUUID
 
 class PeripheralManagerProtocol(ABC):
     """Abstract base class for BLE peripheral/GATT server implementations.
+
+    .. deprecated:: 0.5.0
+        GATT server/peripheral role is out of scope. Use client-side parsing APIs.
+        Scheduled for removal in a future release.
 
     This protocol defines the interface for creating BLE peripherals that
     broadcast services and characteristics. Implementations wrap backend

--- a/src/bluetooth_sig/device/peripheral.py
+++ b/src/bluetooth_sig/device/peripheral.py
@@ -1,10 +1,5 @@
 """Peripheral manager protocol for BLE GATT server adapters.
 
-.. deprecated:: 0.5.0
-    Peripheral/server APIs are out of scope for this library. Prefer client-side
-    :class:`~bluetooth_sig.device.device.Device` with parse/encode. These types
-    will be removed in a future release.
-
 Defines an async abstract base class that peripheral adapter implementations
 (bless, bluez_peripheral, etc.) must inherit from to create BLE GATT servers
 that broadcast services and characteristics.
@@ -29,8 +24,7 @@ class PeripheralManagerProtocol(ABC):
     """Abstract base class for BLE peripheral/GATT server implementations.
 
     .. deprecated:: 0.5.0
-        GATT server/peripheral role is out of scope. Use client-side parsing APIs.
-        Scheduled for removal in a future release.
+        Scheduled for removal; see ``docs/source/explanation/limitations.md``.
 
     This protocol defines the interface for creating BLE peripherals that
     broadcast services and characteristics. Implementations wrap backend

--- a/src/bluetooth_sig/device/peripheral_device.py
+++ b/src/bluetooth_sig/device/peripheral_device.py
@@ -1,10 +1,5 @@
 """High-level peripheral (GATT server) abstraction.
 
-.. deprecated:: 0.5.0
-    ``PeripheralDevice`` is out of scope for this library. Use
-    :class:`~bluetooth_sig.device.device.Device` (client/central) with SIG
-    parse/encode instead. Scheduled for removal in a future release.
-
 Provides :class:`PeripheralDevice`, a server-side helper that hosts GATT
 services and encodes values for remote centrals to read.
 """
@@ -64,9 +59,7 @@ class PeripheralDevice:
     """High-level BLE peripheral abstraction using composition pattern.
 
     .. deprecated:: 0.5.0
-        GATT server/peripheral role is out of scope. Use
-        :class:`~bluetooth_sig.device.device.Device` for client-side workflows.
-        Scheduled for removal in a future release.
+        Scheduled for removal; see ``docs/source/explanation/limitations.md``.
 
     Coordinates between :class:`PeripheralManagerProtocol` (backend) and
     ``BaseCharacteristic`` instances (encoding) so callers work with typed

--- a/src/bluetooth_sig/device/peripheral_device.py
+++ b/src/bluetooth_sig/device/peripheral_device.py
@@ -1,17 +1,18 @@
 """High-level peripheral (GATT server) abstraction.
 
-Provides :class:`PeripheralDevice`, the server-side counterpart to
-:class:`Device`. Where ``Device`` connects TO remote peripherals and reads
-GATT data, ``PeripheralDevice`` **hosts** GATT services and encodes values
-for remote centrals to read.
+.. deprecated:: 0.5.0
+    ``PeripheralDevice`` is out of scope for this library. Use
+    :class:`~bluetooth_sig.device.device.Device` (client/central) with SIG
+    parse/encode instead. Scheduled for removal in a future release.
 
-Composes :class:`PeripheralManagerProtocol` with ``BaseCharacteristic``
-instances that handle value encoding via ``build_value()``.
+Provides :class:`PeripheralDevice`, a server-side helper that hosts GATT
+services and encodes values for remote centrals to read.
 """
 
 from __future__ import annotations
 
 import logging
+import warnings
 
 # Any is required: BaseCharacteristic is generic over its value type (T), but
 # PeripheralDevice hosts heterogeneous characteristics with different T types
@@ -62,6 +63,11 @@ class HostedCharacteristic:
 class PeripheralDevice:
     """High-level BLE peripheral abstraction using composition pattern.
 
+    .. deprecated:: 0.5.0
+        GATT server/peripheral role is out of scope. Use
+        :class:`~bluetooth_sig.device.device.Device` for client-side workflows.
+        Scheduled for removal in a future release.
+
     Coordinates between :class:`PeripheralManagerProtocol` (backend) and
     ``BaseCharacteristic`` instances (encoding) so callers work with typed
     Python values.
@@ -104,6 +110,12 @@ class PeripheralDevice:
             peripheral_manager: Backend implementing PeripheralManagerProtocol.
 
         """
+        warnings.warn(
+            "PeripheralDevice is deprecated and scheduled for removal; "
+            "use client-side Device + parse/encode APIs instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._manager = peripheral_manager
 
         # UUID (normalised upper-case) → HostedCharacteristic

--- a/src/bluetooth_sig/types/peripheral_types.py
+++ b/src/bluetooth_sig/types/peripheral_types.py
@@ -1,10 +1,11 @@
 """Data structures for BLE peripheral/GATT server definitions.
 
+.. deprecated:: 0.5.0
+    Peripheral/server APIs are out of scope and scheduled for removal.
+
 This module provides the data structures used to define GATT services
 and characteristics for peripheral devices. These are used by
-PeripheralManagerProtocol implementations.
-
-Analogous to device_types.py and connected.py structures on the client side.
+:class:`~bluetooth_sig.device.peripheral.PeripheralManagerProtocol` implementations.
 """
 
 from __future__ import annotations

--- a/src/bluetooth_sig/types/peripheral_types.py
+++ b/src/bluetooth_sig/types/peripheral_types.py
@@ -1,11 +1,10 @@
 """Data structures for BLE peripheral/GATT server definitions.
 
-.. deprecated:: 0.5.0
-    Peripheral/server APIs are out of scope and scheduled for removal.
-
 This module provides the data structures used to define GATT services
 and characteristics for peripheral devices. These are used by
 :class:`~bluetooth_sig.device.peripheral.PeripheralManagerProtocol` implementations.
+
+Analogous to device_types.py and connected.py structures on the client side.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- Deprecate `PeripheralDevice`, `PeripheralManagerProtocol`, and `peripheral_types` (docstrings + runtime warning on `PeripheralDevice` init)
- Remove stale ROADMAP.md TODO from `peripheral.py`
- Update `limitations.md` and mark `bless_peripheral.py` example as deprecated
- Tests retained; deprecation is one release cycle before removal

## Test plan
- [x] Quality gates pass locally
- [x] Full test suite green (32 deprecation warnings expected)

Fixes #197

Made with [Cursor](https://cursor.com)