### PR TITLE
Resolve circular dependency: translator ↔ characteristics (custom.py TODO)

### DIFF
--- a/src/bluetooth_sig/gatt/characteristics/custom.py
+++ b/src/bluetooth_sig/gatt/characteristics/custom.py
@@ -17,9 +17,9 @@ class CustomBaseCharacteristic(BaseCharacteristic[Any]):
     and automatic class-level _info binding via __init_subclass__.
 
     Auto-Registration:
-        Custom characteristics automatically register themselves with the global
-        BluetoothSIGTranslator singleton when first instantiated. No manual
-        registration needed!
+        Custom characteristics automatically register with the global
+        characteristic registry via :class:`~bluetooth_sig.core.registration.RegistrationManager`
+        when first instantiated. No manual registration needed!
 
     Examples:
         >>> from bluetooth_sig.types.data_types import CharacteristicInfo
@@ -95,14 +95,14 @@ class CustomBaseCharacteristic(BaseCharacteristic[Any]):
 
         Args:
             info: Optional override for class-configured _info
-            auto_register: If True (default), automatically register with global translator singleton
+            auto_register: If True (default), register via RegistrationManager on first init
             validation: Validation constraints configuration (optional)
 
         Raises:
             ValueError: If no valid info available from class or parameter
 
         Examples:
-            >>> # Simple usage - auto-registers with global translator
+            >>> # Simple usage - auto-registers with global registry
             >>> char = MyCharacteristic()  # Auto-registered!
             >>> # Opt-out of auto-registration if needed
             >>> char = MyCharacteristic(auto_register=False)

--- a/src/bluetooth_sig/gatt/characteristics/custom.py
+++ b/src/bluetooth_sig/gatt/characteristics/custom.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
+from ...core.registration import RegistrationManager
 from ...types import CharacteristicInfo
 from .base import BaseCharacteristic, ValidationConfig
 
@@ -118,28 +119,16 @@ class CustomBaseCharacteristic(BaseCharacteristic[Any]):
 
         # Auto-register if requested and not already registered
         if auto_register:
-            # TODO: Refactor to eliminate circular dependency (translator ↔ characteristics).
-            #   Deferred import used as workaround — consider a registration broker pattern.
-            from ...core.translator import (  # noqa: PLC0415
-                BluetoothSIGTranslator,  # pylint: disable=import-outside-toplevel
-            )
-
-            # Get the singleton translator instance
-            translator = BluetoothSIGTranslator.get_instance()
-
-            # Track registration to avoid duplicate registrations
             uuid_str = str(final_info.uuid)
-            registry_key = f"{id(translator)}:{uuid_str}"
 
-            if registry_key not in CustomBaseCharacteristic._registry_tracker:
-                # Register this characteristic class with the translator
-                # Use override=True to allow re-registration (idempotent behaviour)
-                translator.register_custom_characteristic_class(
+            if uuid_str not in CustomBaseCharacteristic._registry_tracker:
+                RegistrationManager.register_custom_characteristic_class(
                     uuid_str,
                     self.__class__,
-                    override=True,  # Allow override for idempotent registration
+                    info=final_info,
+                    override=True,
                 )
-                CustomBaseCharacteristic._registry_tracker.add(registry_key)
+                CustomBaseCharacteristic._registry_tracker.add(uuid_str)
 
         # Call parent constructor with our info to maintain consistency
         super().__init__(info=final_info, validation=validation)


### PR DESCRIPTION
## Summary
- Route `CustomBaseCharacteristic` auto-registration through `RegistrationManager` instead of `BluetoothSIGTranslator.get_instance()`
- Removes deferred translator import and the TODO in `custom.py`
- Passes `CharacteristicInfo` to registration for uuid registry metadata

## Test plan
- [x] `./scripts/lint.sh --all`
- [x] `tests/integration/test_custom_registration.py` passes

Fixes #200

Made with [Cursor](https://cursor.com)