### PR TITLE
Expose User Description descriptor labels on discovered characteristics

### DIFF
--- a/docs/source/how-to/usage.md
+++ b/docs/source/how-to/usage.md
@@ -323,26 +323,6 @@ results = BluetoothSIGTranslator().parse_characteristics(char_data)
 
 For BLE library integration patterns (bleak, simplepyble, etc.), see the [BLE Integration Guide](ble-integration.md) and [Migration Guide](migration.md).
 
-### User Description labels (optional enrichment)
-
-When you read the **User Description** descriptor (`0x2901`) for a characteristic, pass the parent characteristic UUID to `read_descriptor` so the parsed UTF-8 label is stored on the cached characteristic instance:
-
-```python
-# SKIP: Requires BLE connection and Device instance
-from bluetooth_sig.gatt.descriptors.characteristic_user_description import (
-    CharacteristicUserDescriptionDescriptor,
-)
-
-battery_uuid = "2A19"
-await device.read_descriptor(
-    CharacteristicUserDescriptionDescriptor(),
-    characteristic_uuid=battery_uuid,
-)
-label = device.get_user_description_for_characteristic(battery_uuid)
-```
-
-You can also attach bytes from an adapter without a separate read via `device.attach_user_description(uuid, raw_bytes)`. This is metadata only — it does not change characteristic parse/encode behaviour.
-
 ______________________________________________________________________
 
 ## Troubleshooting
@@ -362,12 +342,19 @@ The `Device` class provides high-level device abstraction with service discovery
 # SKIP: Requires BLE hardware and ConnectionManagerProtocol implementation
 from bluetooth_sig import BluetoothSIGTranslator, Device
 from bluetooth_sig.gatt.characteristics import BatteryLevelCharacteristic
+from bluetooth_sig.gatt.descriptors.characteristic_user_description import (
+    CharacteristicUserDescriptionDescriptor,
+)
 
 # connection_manager implements ConnectionManagerProtocol
 device = Device(connection_manager, BluetoothSIGTranslator())
 
 await device.connect()
 await device.discover_services()
+
+battery_uuid = str(BatteryLevelCharacteristic.get_class_uuid())
+await device.read_descriptor(CharacteristicUserDescriptionDescriptor(), characteristic_uuid=battery_uuid)
+label = device.get_user_description_for_characteristic(battery_uuid)  # metadata only
 
 # Type-safe read
 battery = await device.read(BatteryLevelCharacteristic)

--- a/docs/source/how-to/usage.md
+++ b/docs/source/how-to/usage.md
@@ -323,6 +323,26 @@ results = BluetoothSIGTranslator().parse_characteristics(char_data)
 
 For BLE library integration patterns (bleak, simplepyble, etc.), see the [BLE Integration Guide](ble-integration.md) and [Migration Guide](migration.md).
 
+### User Description labels (optional enrichment)
+
+When you read the **User Description** descriptor (`0x2901`) for a characteristic, pass the parent characteristic UUID to `read_descriptor` so the parsed UTF-8 label is stored on the cached characteristic instance:
+
+```python
+# SKIP: Requires BLE connection and Device instance
+from bluetooth_sig.gatt.descriptors.characteristic_user_description import (
+    CharacteristicUserDescriptionDescriptor,
+)
+
+battery_uuid = "2A19"
+await device.read_descriptor(
+    CharacteristicUserDescriptionDescriptor(),
+    characteristic_uuid=battery_uuid,
+)
+label = device.get_user_description_for_characteristic(battery_uuid)
+```
+
+You can also attach bytes from an adapter without a separate read via `device.attach_user_description(uuid, raw_bytes)`. This is metadata only — it does not change characteristic parse/encode behaviour.
+
 ______________________________________________________________________
 
 ## Troubleshooting

--- a/src/bluetooth_sig/device/device.py
+++ b/src/bluetooth_sig/device/device.py
@@ -15,6 +15,10 @@ from ..gatt.characteristics.base import BaseCharacteristic
 from ..gatt.characteristics.registry import CharacteristicName
 from ..gatt.context import DeviceInfo
 from ..gatt.descriptors.base import BaseDescriptor
+from ..gatt.descriptors.characteristic_user_description import (
+    CharacteristicUserDescriptionData,
+    CharacteristicUserDescriptionDescriptor,
+)
 from ..gatt.descriptors.registry import DescriptorRegistry
 from ..types import (
     DescriptorData,
@@ -314,11 +318,19 @@ class Device:  # pylint: disable=too-many-instance-attributes,too-many-public-me
         """
         await self._char_io.stop_notify(char_name)
 
-    async def read_descriptor(self, desc_uuid: BluetoothUUID | BaseDescriptor) -> DescriptorData:
+    async def read_descriptor(
+        self,
+        desc_uuid: BluetoothUUID | BaseDescriptor,
+        *,
+        characteristic_uuid: BluetoothUUID | str | None = None,
+    ) -> DescriptorData:
         """Read a descriptor value from the device.
 
         Args:
             desc_uuid: UUID of the descriptor to read or BaseDescriptor instance
+            characteristic_uuid: When reading a characteristic-scoped descriptor
+                (e.g. User Description 0x2901), pass the parent characteristic
+                UUID to store the parsed label on that characteristic instance.
 
         Returns:
             Parsed descriptor data with metadata
@@ -335,16 +347,73 @@ class Device:  # pylint: disable=too-many-instance-attributes,too-many-public-me
         # Try to create a descriptor instance and parse the data
         descriptor = DescriptorRegistry.create_descriptor(str(uuid))
         if descriptor:
-            return descriptor.parse_value(raw_data)
+            parsed = descriptor.parse_value(raw_data)
+            if characteristic_uuid is not None:
+                self._attach_user_description_from_descriptor(characteristic_uuid, uuid, parsed)
+            return parsed
 
         # If no registered descriptor found, return unparsed DescriptorData
-        return DescriptorData(
+        unparsed = DescriptorData(
             info=DescriptorInfo(uuid=uuid, name="Unknown Descriptor"),
             value=raw_data,
             raw_data=raw_data,
             parse_success=False,
             error_message="Unknown descriptor UUID - no parser available",
         )
+        if characteristic_uuid is not None:
+            self._attach_user_description_from_descriptor(characteristic_uuid, uuid, unparsed)
+        return unparsed
+
+    def attach_user_description(self, characteristic_uuid: BluetoothUUID | str, raw_bytes: bytes) -> str | None:
+        """Parse and store User Description bytes on a cached characteristic.
+
+        Args:
+            characteristic_uuid: Parent characteristic UUID
+            raw_bytes: Raw User Description descriptor bytes (UTF-8)
+
+        Returns:
+            Parsed description string, or None if characteristic not cached
+        """
+        char = self.connected.get_cached_characteristic(BluetoothUUID(characteristic_uuid))
+        if char is None:
+            return None
+        descriptor = CharacteristicUserDescriptionDescriptor()
+        parsed = descriptor.parse_value(raw_bytes)
+        if isinstance(parsed.value, CharacteristicUserDescriptionData):
+            char.user_description = parsed.value.description
+            return char.user_description
+        return None
+
+    def get_user_description_for_characteristic(self, characteristic_uuid: BluetoothUUID | str) -> str | None:
+        """Return cached User Description label for a characteristic, if set.
+
+        Args:
+            characteristic_uuid: Characteristic UUID from discovered services
+
+        Returns:
+            User Description string when previously read or attached, else None
+        """
+        char = self.connected.get_cached_characteristic(BluetoothUUID(characteristic_uuid))
+        return char.user_description if char is not None else None
+
+    def _attach_user_description_from_descriptor(
+        self,
+        characteristic_uuid: BluetoothUUID | str,
+        descriptor_uuid: BluetoothUUID,
+        descriptor_data: DescriptorData,
+    ) -> None:
+        """Store User Description text on the parent characteristic when applicable."""
+        user_desc_uuid = CharacteristicUserDescriptionDescriptor().uuid
+        if BluetoothUUID(descriptor_uuid).normalized != user_desc_uuid.normalized:
+            return
+        char = self.connected.get_cached_characteristic(BluetoothUUID(characteristic_uuid))
+        if char is None:
+            return
+        value = descriptor_data.value
+        if isinstance(value, CharacteristicUserDescriptionData):
+            char.user_description = value.description
+        elif isinstance(value, str):
+            char.user_description = value
 
     async def write_descriptor(self, desc_uuid: BluetoothUUID | BaseDescriptor, data: bytes | DescriptorData) -> None:
         """Write data to a descriptor on the device.

--- a/src/bluetooth_sig/gatt/characteristics/base.py
+++ b/src/bluetooth_sig/gatt/characteristics/base.py
@@ -154,6 +154,9 @@ class BaseCharacteristic(ContextLookupMixin, DescriptorMixin, ABC, Generic[T], m
         # Last parsed value for caching/debugging
         self.last_parsed: T | None = None
 
+        # Optional User Description (0x2901) label from device discovery
+        self.user_description: str | None = None
+
         # Pipeline composition — validator is shared by parse and encode pipelines
         self._validator = CharacteristicValidator(self)
         self._parse_pipeline = ParsePipeline(self, self._validator)

--- a/tests/device/test_user_description_metadata.py
+++ b/tests/device/test_user_description_metadata.py
@@ -51,6 +51,18 @@ class TestUserDescriptionMetadata:
 
         assert device_with_battery.get_user_description_for_characteristic(battery_uuid) == "Outdoor sensor"
 
+    @pytest.mark.asyncio
+    async def test_read_descriptor_without_characteristic_uuid_does_not_attach(
+        self, device_with_battery: Device
+    ) -> None:
+        """read_descriptor without parent UUID must not mutate characteristic metadata."""
+        battery_uuid = str(BatteryLevelCharacteristic.get_class_uuid())
+        user_desc = CharacteristicUserDescriptionDescriptor()
+
+        await device_with_battery.read_descriptor(user_desc)
+
+        assert device_with_battery.get_user_description_for_characteristic(battery_uuid) is None
+
     def test_attach_user_description_from_raw_bytes(self, device_with_battery: Device) -> None:
         """attach_user_description parses UTF-8 without a live descriptor read."""
         battery_uuid = str(BatteryLevelCharacteristic.get_class_uuid())

--- a/tests/device/test_user_description_metadata.py
+++ b/tests/device/test_user_description_metadata.py
@@ -1,0 +1,64 @@
+"""Tests for User Description metadata on discovered characteristics."""
+
+from __future__ import annotations
+
+import pytest
+
+from bluetooth_sig import BluetoothSIGTranslator
+from bluetooth_sig.device import Device
+from bluetooth_sig.device.connected import DeviceService
+from bluetooth_sig.gatt.characteristics import BatteryLevelCharacteristic
+from bluetooth_sig.gatt.descriptors.characteristic_user_description import (
+    CharacteristicUserDescriptionDescriptor,
+)
+from bluetooth_sig.gatt.services import BatteryService
+from bluetooth_sig.types.uuid import BluetoothUUID
+from tests.device.test_device_async_methods import AsyncMockClientManager
+
+
+class UserDescriptionMockClient(AsyncMockClientManager):
+    """Mock client returning User Description UTF-8 bytes."""
+
+    async def read_gatt_descriptor(self, desc_uuid: BluetoothUUID) -> bytes:
+        return b"Outdoor sensor"
+
+
+@pytest.fixture
+def device_with_battery() -> Device:
+    """Device with battery service discovered and cached."""
+    device = Device(UserDescriptionMockClient(), BluetoothSIGTranslator())
+    battery = BatteryLevelCharacteristic()
+    service_uuid = BatteryService.get_class_uuid()
+    service = DeviceService(
+        uuid=service_uuid,
+        service_class=BatteryService,
+        characteristics={str(battery.uuid): battery},
+    )
+    device.connected.services[str(service_uuid)] = service
+    return device
+
+
+class TestUserDescriptionMetadata:
+    """User Description labels attach to characteristic metadata only."""
+
+    @pytest.mark.asyncio
+    async def test_read_descriptor_stores_user_description(self, device_with_battery: Device) -> None:
+        """read_descriptor with characteristic_uuid caches parsed label."""
+        battery_uuid = str(BatteryLevelCharacteristic.get_class_uuid())
+        user_desc = CharacteristicUserDescriptionDescriptor()
+
+        await device_with_battery.read_descriptor(user_desc, characteristic_uuid=battery_uuid)
+
+        assert device_with_battery.get_user_description_for_characteristic(battery_uuid) == "Outdoor sensor"
+
+    def test_attach_user_description_from_raw_bytes(self, device_with_battery: Device) -> None:
+        """attach_user_description parses UTF-8 without a live descriptor read."""
+        battery_uuid = str(BatteryLevelCharacteristic.get_class_uuid())
+        label = device_with_battery.attach_user_description(battery_uuid, b"Indoor sensor")
+
+        assert label == "Indoor sensor"
+        assert device_with_battery.get_user_description_for_characteristic(battery_uuid) == "Indoor sensor"
+
+    def test_get_user_description_missing_characteristic(self, device_with_battery: Device) -> None:
+        """Unknown characteristic UUID returns None."""
+        assert device_with_battery.get_user_description_for_characteristic("FFFF") is None


### PR DESCRIPTION
## Summary
- Add `user_description` metadata field on `BaseCharacteristic`
- Extend `Device.read_descriptor(..., characteristic_uuid=...)` to cache parsed User Description (0x2901)
- Add `attach_user_description()` and `get_user_description_for_characteristic()` helpers
- Document optional enrichment in `usage.md`

## Test plan
- [x] Quality gates pass
- [x] `tests/device/test_user_description_metadata.py`

Fixes #195

Made with [Cursor](https://cursor.com)