### PR TITLE
Add opt-in GATT service compliance validation after discovery

### DIFF
--- a/docs/source/how-to/usage.md
+++ b/docs/source/how-to/usage.md
@@ -349,6 +349,12 @@ device = Device(connection_manager, BluetoothSIGTranslator())
 await device.connect()
 await device.discover_services()
 
+# Optional: validate discovered services against SIG definitions (no extra BLE reads)
+validations = device.validate_discovered_services()
+for result in validations:
+    if not result.validation.is_healthy:
+        print(f"{result.service_name}: missing required characteristics")
+
 # Type-safe read
 battery = await device.read(BatteryLevelCharacteristic)
 print(f"Battery: {battery}%")

--- a/docs/source/how-to/usage.md
+++ b/docs/source/how-to/usage.md
@@ -349,11 +349,8 @@ device = Device(connection_manager, BluetoothSIGTranslator())
 await device.connect()
 await device.discover_services()
 
-# Optional: validate discovered services against SIG definitions (no extra BLE reads)
-validations = device.validate_discovered_services()
-for result in validations:
-    if not result.validation.is_healthy:
-        print(f"{result.service_name}: missing required characteristics")
+# Optional: validate discovered services — see [Service validation](services.md#service-validation)
+device.validate_discovered_services()
 
 # Type-safe read
 battery = await device.read(BatteryLevelCharacteristic)

--- a/src/bluetooth_sig/device/__init__.py
+++ b/src/bluetooth_sig/device/__init__.py
@@ -27,6 +27,7 @@ from bluetooth_sig.device.peripheral import (
 )
 from bluetooth_sig.device.peripheral_device import PeripheralDevice
 from bluetooth_sig.device.protocols import SIGTranslatorProtocol
+from bluetooth_sig.device.validation import DiscoveredServiceValidation
 
 __all__ = [
     "CharacteristicDefinition",
@@ -37,6 +38,7 @@ __all__ = [
     "DeviceConnected",
     "DeviceEncryption",
     "DeviceService",
+    "DiscoveredServiceValidation",
     "PeripheralDevice",
     "PeripheralManagerProtocol",
     "ServiceDefinition",

--- a/src/bluetooth_sig/device/device.py
+++ b/src/bluetooth_sig/device/device.py
@@ -30,6 +30,7 @@ from .client import ClientManagerProtocol
 from .connected import DeviceConnected, DeviceEncryption, DeviceService
 from .dependency_resolver import DependencyResolutionMode, DependencyResolver
 from .protocols import SIGTranslatorProtocol
+from .validation import DiscoveredServiceValidation, validate_device_services
 
 # Type variable for generic characteristic return types
 T = TypeVar("T")
@@ -520,6 +521,23 @@ class Device:  # pylint: disable=too-many-instance-attributes,too-many-public-me
 
         # Return as dict for backward compatibility
         return {str(svc.uuid): svc for svc in services_list}
+
+    def validate_discovered_services(self, *, strict: bool = False) -> list[DiscoveredServiceValidation]:
+        """Validate discovered services against SIG service definitions.
+
+        Opt-in compliance check using the discovered service/characteristic UUID
+        set from the last :meth:`discover_services` call. No additional BLE
+        reads are performed.
+
+        Args:
+            strict: When ``True``, missing optional characteristics produce warnings.
+
+        Returns:
+            Validation results for each discovered service with a known SIG
+            implementation. Unknown vendor services are omitted.
+
+        """
+        return validate_device_services(self.connected.services, strict=strict)
 
     async def get_characteristic_info(self, char_uuid: str) -> Any | None:  # noqa: ANN401  # Adapter-specific characteristic metadata
         """Get information about a characteristic from the connection manager.

--- a/src/bluetooth_sig/device/validation.py
+++ b/src/bluetooth_sig/device/validation.py
@@ -1,0 +1,59 @@
+"""Opt-in GATT service compliance validation for discovered devices."""
+
+from __future__ import annotations
+
+import msgspec
+
+from ..gatt.services.base import BaseGattService, ServiceValidationResult
+from ..types.uuid import BluetoothUUID
+from .connected import DeviceService
+
+
+class DiscoveredServiceValidation(msgspec.Struct, kw_only=True, frozen=True):
+    """Validation result for a single discovered GATT service."""
+
+    service_uuid: BluetoothUUID
+    service_name: str
+    validation: ServiceValidationResult
+
+
+def validate_device_services(
+    services: dict[str, DeviceService],
+    *,
+    strict: bool = False,
+) -> list[DiscoveredServiceValidation]:
+    """Validate discovered services against SIG service definitions.
+
+    Args:
+        services: Discovered services keyed by UUID string (from ``DeviceConnected.services``).
+        strict: When ``True``, missing optional characteristics produce warnings.
+
+    Returns:
+        Validation results for each discovered service with a known SIG implementation.
+        Unknown vendor services (no registered service class) are skipped.
+    """
+    results: list[DiscoveredServiceValidation] = []
+    for device_service in services.values():
+        if device_service.service_class is None:
+            continue
+
+        service = _build_service_instance(device_service)
+        validation = service.validate_service(strict=strict)
+        results.append(
+            DiscoveredServiceValidation(
+                service_uuid=device_service.uuid,
+                service_name=service.name,
+                validation=validation,
+            )
+        )
+    return results
+
+
+def _build_service_instance(device_service: DeviceService) -> BaseGattService:
+    """Instantiate a SIG service and attach discovered characteristics."""
+    service_class = device_service.service_class
+    assert service_class is not None
+    service = service_class()
+    for characteristic in device_service.characteristics.values():
+        service.characteristics[characteristic.uuid] = characteristic
+    return service

--- a/src/bluetooth_sig/device/validation.py
+++ b/src/bluetooth_sig/device/validation.py
@@ -52,7 +52,8 @@ def validate_device_services(
 def _build_service_instance(device_service: DeviceService) -> BaseGattService:
     """Instantiate a SIG service and attach discovered characteristics."""
     service_class = device_service.service_class
-    assert service_class is not None
+    if service_class is None:
+        raise ValueError("device_service.service_class must be set for SIG validation")
     service = service_class()
     for characteristic in device_service.characteristics.values():
         service.characteristics[characteristic.uuid] = characteristic

--- a/tests/device/test_service_compliance_validation.py
+++ b/tests/device/test_service_compliance_validation.py
@@ -1,0 +1,174 @@
+"""Tests for opt-in GATT service compliance validation after discovery."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from bluetooth_sig import BluetoothSIGTranslator
+from bluetooth_sig.device import Device
+from bluetooth_sig.device.client import ClientManagerProtocol
+from bluetooth_sig.gatt.characteristics import BatteryLevelCharacteristic
+from bluetooth_sig.gatt.services import BatteryService, ServiceHealthStatus
+from bluetooth_sig.gatt.services.base import ServiceValidationResult
+from bluetooth_sig.types.advertising.ad_structures import AdvertisingDataStructures, CoreAdvertisingData
+from bluetooth_sig.types.advertising.result import AdvertisementData
+from bluetooth_sig.types.device_types import DeviceService as ClientDeviceService
+from bluetooth_sig.types.uuid import BluetoothUUID
+
+
+class ValidationMockClientManager(ClientManagerProtocol):
+    """Mock connection manager for service validation tests."""
+
+    def __init__(self, address: str = "AA:BB:CC:DD:EE:FF", **kwargs: object) -> None:
+        super().__init__(address, **kwargs)
+        self._connected = True
+        self._services: list[ClientDeviceService] = []
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    @property
+    def mtu_size(self) -> int:
+        return 247
+
+    @property
+    def name(self) -> str:
+        return "Validation Mock Device"
+
+    async def connect(self, *, timeout: float = 10.0) -> None:
+        self._connected = True
+
+    async def disconnect(self) -> None:
+        self._connected = False
+
+    async def read_gatt_char(self, char_uuid: BluetoothUUID) -> bytes:
+        return b"\x64"
+
+    async def write_gatt_char(self, char_uuid: BluetoothUUID, data: bytes, response: bool = True) -> None:
+        pass
+
+    async def read_gatt_descriptor(self, desc_uuid: BluetoothUUID) -> bytes:
+        return b""
+
+    async def write_gatt_descriptor(self, desc_uuid: BluetoothUUID, data: bytes) -> None:
+        pass
+
+    async def get_services(self) -> list[ClientDeviceService]:
+        return self._services
+
+    async def start_notify(self, char_uuid: BluetoothUUID, callback: Callable[[str, bytes], None]) -> None:
+        pass
+
+    async def stop_notify(self, char_uuid: BluetoothUUID) -> None:
+        pass
+
+    async def pair(self) -> None:
+        pass
+
+    async def unpair(self) -> None:
+        pass
+
+    async def read_rssi(self) -> int:
+        return -55
+
+    async def get_advertisement_rssi(self, refresh: bool = False) -> int | None:
+        return -65
+
+    def set_disconnected_callback(self, callback: Callable[[], None]) -> None:
+        pass
+
+    @classmethod
+    def convert_advertisement(cls, _advertisement: object) -> AdvertisementData:
+        return AdvertisementData(
+            ad_structures=AdvertisingDataStructures(core=CoreAdvertisingData()),
+        )
+
+    async def get_latest_advertisement(self, refresh: bool = False) -> AdvertisementData | None:
+        return None
+
+
+@pytest.fixture
+def validation_device() -> tuple[Device, ValidationMockClientManager]:
+    """Device with mock manager for validation tests."""
+    manager = ValidationMockClientManager()
+    device = Device(manager, BluetoothSIGTranslator())
+    return device, manager
+
+
+class TestValidateDiscoveredServices:
+    """Tests for Device.validate_discovered_services()."""
+
+    @pytest.mark.asyncio
+    async def test_compliant_battery_service(
+        self, validation_device: tuple[Device, ValidationMockClientManager]
+    ) -> None:
+        """Battery Service with required Battery Level characteristic is healthy."""
+        device, manager = validation_device
+        battery_char = BatteryLevelCharacteristic()
+        manager._services = [
+            ClientDeviceService(
+                service=BatteryService(),
+                characteristics={str(battery_char.uuid): battery_char},
+            )
+        ]
+
+        await device.discover_services()
+        results = device.validate_discovered_services()
+
+        assert len(results) == 1
+        assert results[0].service_uuid.short_form == "180F"
+        assert results[0].service_name == "Battery"
+        assert results[0].validation.status == ServiceHealthStatus.COMPLETE
+        assert results[0].validation.is_healthy is True
+        assert results[0].validation.missing_required == []
+
+    @pytest.mark.asyncio
+    async def test_non_compliant_battery_service_missing_level(
+        self, validation_device: tuple[Device, ValidationMockClientManager]
+    ) -> None:
+        """Battery Service without Battery Level is reported as incomplete."""
+        device, manager = validation_device
+        manager._services = [ClientDeviceService(service=BatteryService(), characteristics={})]
+
+        await device.discover_services()
+        results = device.validate_discovered_services()
+
+        assert len(results) == 1
+        assert results[0].validation.status == ServiceHealthStatus.INCOMPLETE
+        assert results[0].validation.is_healthy is False
+        assert results[0].validation.has_errors is True
+        battery_level_missing = any(char.name == "Battery Level" for char in results[0].validation.missing_required)
+        assert battery_level_missing
+
+    @pytest.mark.asyncio
+    async def test_empty_discovery_returns_empty_results(
+        self, validation_device: tuple[Device, ValidationMockClientManager]
+    ) -> None:
+        """No discovered services yields an empty validation list."""
+        device, manager = validation_device
+        manager._services = []
+
+        await device.discover_services()
+        results = device.validate_discovered_services()
+
+        assert results == []
+
+    def test_validate_device_services_unit(self) -> None:
+        """validate_device_services helper validates without a Device instance."""
+        from bluetooth_sig.device.connected import DeviceService
+        from bluetooth_sig.device.validation import validate_device_services
+
+        battery_char = BatteryLevelCharacteristic()
+        device_service = DeviceService(
+            uuid=BatteryService.get_class_uuid(),
+            service_class=BatteryService,
+            characteristics={str(battery_char.uuid): battery_char},
+        )
+        results = validate_device_services({str(device_service.uuid): device_service})
+
+        assert len(results) == 1
+        assert isinstance(results[0].validation, ServiceValidationResult)
+        assert results[0].validation.is_healthy is True

--- a/tests/device/test_service_compliance_validation.py
+++ b/tests/device/test_service_compliance_validation.py
@@ -9,6 +9,8 @@ import pytest
 from bluetooth_sig import BluetoothSIGTranslator
 from bluetooth_sig.device import Device
 from bluetooth_sig.device.client import ClientManagerProtocol
+from bluetooth_sig.device.connected import DeviceService
+from bluetooth_sig.device.validation import validate_device_services
 from bluetooth_sig.gatt.characteristics import BatteryLevelCharacteristic
 from bluetooth_sig.gatt.services import BatteryService, ServiceHealthStatus
 from bluetooth_sig.gatt.services.base import ServiceValidationResult
@@ -156,11 +158,18 @@ class TestValidateDiscoveredServices:
 
         assert results == []
 
+    def test_unknown_vendor_service_skipped(self) -> None:
+        """Services without a registered SIG class are omitted from results."""
+        unknown = DeviceService(
+            uuid=BluetoothUUID("FF00"),
+            service_class=None,
+            characteristics={},
+        )
+        results = validate_device_services({str(unknown.uuid): unknown})
+        assert results == []
+
     def test_validate_device_services_unit(self) -> None:
         """validate_device_services helper validates without a Device instance."""
-        from bluetooth_sig.device.connected import DeviceService
-        from bluetooth_sig.device.validation import validate_device_services
-
         battery_char = BatteryLevelCharacteristic()
         device_service = DeviceService(
             uuid=BatteryService.get_class_uuid(),


### PR DESCRIPTION
## Summary

- Adds `Device.validate_discovered_services()` — opt-in SIG compliance checks using discovered service/characteristic UUID sets (no extra BLE reads)
- Introduces `DiscoveredServiceValidation` and `validate_device_services()` helper in `device/validation.py`
- Documents usage in `docs/source/how-to/usage.md`
- Tests: compliant Battery Service, missing Battery Level, empty discovery

Closes #193

## Test plan

- [x] `./scripts/format.sh --fix && ./scripts/format.sh --check`
- [x] `./scripts/lint.sh --all`
- [x] `python -m pytest tests/ -v`

Made with [Cursor](https://cursor.com)